### PR TITLE
Fix tracking variable mapping in Job object.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.2.2</version>
+      <version>2.3</version>
     </dependency>
 	<dependency>
 		<groupId>commons-codec</groupId>

--- a/src/main/java/com/lob/model/Job.java
+++ b/src/main/java/com/lob/model/Job.java
@@ -16,7 +16,7 @@ public class Job extends APIResource {
 	Object[] objects;
     Integer quantity;
     String status;
-    String tracking;
+    Object tracking;
 	Packaging packaging;
 	Service service;
 	String object;
@@ -61,7 +61,7 @@ public class Job extends APIResource {
 	}
 
 
-	public String getTracking() {
+	public Object getTracking() {
 		return tracking;
 	}
 


### PR DESCRIPTION
It was changed from String to the Object.
gson was updated up to version 2.3
