### PR TITLE
feat(addresses): add company to addresses and removes checkPresent

### DIFF
--- a/src/main/java/com/lob/protocol/request/AddressRequest.java
+++ b/src/main/java/com/lob/protocol/request/AddressRequest.java
@@ -8,17 +8,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.lob.Util.checkNotNull;
-import static com.lob.Util.checkPresent;
 
 public class AddressRequest extends AbstractAddressRequest implements HasLobParams {
     private final static int MAX_LENGTH = 50;
 
     private final String name;
+    private final String company;
     private final String email;
     private final String phone;
 
     public AddressRequest(
             final String name,
+            final String company,
             final String email,
             final String phone,
             final String line1,
@@ -41,7 +42,8 @@ public class AddressRequest extends AbstractAddressRequest implements HasLobPara
             metadata,
             description);
 
-        this.name = checkPresent(name, "name is required");
+        this.name = name;
+        this.company = company;
         this.email = email;
         this.phone = phone;
     }
@@ -50,6 +52,7 @@ public class AddressRequest extends AbstractAddressRequest implements HasLobPara
     public Collection<LobParam> getLobParams() {
         return super.beginParams()
             .put("name", name)
+            .put("company", company)
             .put("email", email)
             .put("phone", phone)
             .build();
@@ -62,6 +65,9 @@ public class AddressRequest extends AbstractAddressRequest implements HasLobPara
     public String getName() {
         return name;
     }
+    public String getCompany() {
+        return company;
+    }
 
     public String getEmail() {
         return email;
@@ -73,8 +79,10 @@ public class AddressRequest extends AbstractAddressRequest implements HasLobPara
 
     @Override
     public String toString() {
+
         return "AddressRequest{" +
             "name='" + name + '\'' +
+            ", company='" + company + '\'' +
             ", email='" + email + '\'' +
             ", phone='" + phone + '\'' +
             super.toString();
@@ -82,6 +90,7 @@ public class AddressRequest extends AbstractAddressRequest implements HasLobPara
 
     public static class Builder extends AbstractLobRequest.Builder<Builder> {
         private String name;
+        private String company;
         private String email;
         private String phone;
         private String line1;
@@ -96,6 +105,11 @@ public class AddressRequest extends AbstractAddressRequest implements HasLobPara
 
         public Builder name(final String name) {
             this.name = name;
+            return this;
+        }
+
+        public Builder company(final String company) {
+            this.company = company;
             return this;
         }
 
@@ -152,6 +166,7 @@ public class AddressRequest extends AbstractAddressRequest implements HasLobPara
         public Builder butWith() {
             return new Builder()
                 .name(name)
+                .company(company)
                 .email(email)
                 .phone(phone)
                 .line1(line1)
@@ -165,7 +180,7 @@ public class AddressRequest extends AbstractAddressRequest implements HasLobPara
         }
 
         public AddressRequest build() {
-            return new AddressRequest(name, email, phone, line1, line2, city, state, zip, country, metadata, description);
+            return new AddressRequest(name, company, email, phone, line1, line2, city, state, zip, country, metadata, description);
         }
     }
 }

--- a/src/main/java/com/lob/protocol/response/AddressResponse.java
+++ b/src/main/java/com/lob/protocol/response/AddressResponse.java
@@ -12,6 +12,7 @@ import java.util.Map;
 public class AddressResponse extends BaseAddressResponse {
     @JsonProperty private final AddressId id;
     @JsonProperty private final String name;
+    @JsonProperty private final String company;
     @JsonProperty private final String email;
     @JsonProperty private final String phone;
     @JsonProperty private final DateTime dateCreated;
@@ -22,6 +23,7 @@ public class AddressResponse extends BaseAddressResponse {
     public AddressResponse(
             @JsonProperty("id") final AddressId id,
             @JsonProperty("name") final String name,
+            @JsonProperty("company") final String company,
             @JsonProperty("email") final String email,
             @JsonProperty("phone") final String phone,
             @JsonProperty("address_line1") final String line1,
@@ -38,6 +40,7 @@ public class AddressResponse extends BaseAddressResponse {
         super(line1, line2, city, state, zip, country, object);
         this.id = id;
         this.name = name;
+        this.company = company;
         this.email = email;
         this.phone = phone;
         this.dateCreated = dateCreated;
@@ -51,6 +54,9 @@ public class AddressResponse extends BaseAddressResponse {
 
     public String getName() {
         return name;
+    }
+    public String getCompany() {
+        return company;
     }
 
     public String getEmail() {
@@ -78,6 +84,7 @@ public class AddressResponse extends BaseAddressResponse {
         return "AddressResponse{" +
             "id=" + id +
             ", name='" + name + '\'' +
+            ", company='" + company + '\'' +
             ", email='" + email + '\'' +
             ", phone='" + phone + '\'' +
             ", dateCreated=" + dateCreated +

--- a/src/test/java/com/lob/client/test/AddressTest.java
+++ b/src/test/java/com/lob/client/test/AddressTest.java
@@ -85,6 +85,7 @@ public class AddressTest extends BaseTest {
 
         final AddressRequest.Builder builder = AddressRequest.builder()
             .name("Lob")
+            .company("Lob")
             .email("support@lob.com")
             .phone("555-555-5555")
             .line1("185 Berry Street")
@@ -98,6 +99,7 @@ public class AddressTest extends BaseTest {
         final AddressResponse response = client.createAddress(builder.build()).get();
         assertTrue(response instanceof AddressResponse);
         assertThat(response.getName(), is("Lob"));
+        assertThat(response.getCompany(), is("Lob"));
 
         assertFalse(response.getEmail().isEmpty());
         assertFalse(response.getPhone().isEmpty());
@@ -124,6 +126,7 @@ public class AddressTest extends BaseTest {
         assertFalse(request.getState().isEmpty());
         assertTrue(request.getCountry() instanceof CountryCode);
         assertThat(request.getName(), is("Lob"));
+        assertThat(request.getCompany(), is("Lob"));
         assertTrue(request.getZip() instanceof ZipCode);
 
         final AddressId id = response.getId();


### PR DESCRIPTION
What: 
- Adds `company` support to AddressRequest and AddressResponse
- Removes checkPresent on name

@pon 