### PR TITLE
fix(status): remove status fields from wrapper

### DIFF
--- a/src/main/java/com/lob/protocol/response/AreaMailResponse.java
+++ b/src/main/java/com/lob/protocol/response/AreaMailResponse.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 public class AreaMailResponse extends AbstractLobResponse {
     @JsonProperty private final AreaMailId id;
-    @JsonProperty private final String status;
     @JsonProperty private final Money price;
     @JsonProperty private final String url;
     @JsonProperty private final TargetType targetType;
@@ -24,7 +23,6 @@ public class AreaMailResponse extends AbstractLobResponse {
     @JsonCreator
     public AreaMailResponse(
             @JsonProperty("id") final AreaMailId id,
-            @JsonProperty("status") final String status,
             @JsonProperty("price") final Money price,
             @JsonProperty("url") final String url,
             @JsonProperty("target_type") final TargetType targetType,
@@ -38,7 +36,6 @@ public class AreaMailResponse extends AbstractLobResponse {
             @JsonProperty("object") final String object) {
         super(dateCreated, dateModified, metadata, object);
         this.id = id;
-        this.status = status;
         this.price = price;
         this.url = url;
         this.targetType = targetType;
@@ -50,10 +47,6 @@ public class AreaMailResponse extends AbstractLobResponse {
 
     public AreaMailId getId() {
         return id;
-    }
-
-    public String getStatus() {
-        return status;
     }
 
     public Money getPrice() {
@@ -88,7 +81,6 @@ public class AreaMailResponse extends AbstractLobResponse {
     public String toString() {
         return "AreaMailResponse{" +
             "id=" + id +
-            ", status='" + status + '\'' +
             ", price=" + price +
             ", url='" + url + '\'' +
             ", targetType=" + targetType +

--- a/src/main/java/com/lob/protocol/response/CheckResponse.java
+++ b/src/main/java/com/lob/protocol/response/CheckResponse.java
@@ -18,7 +18,6 @@ public class CheckResponse extends AbstractLobResponse {
     @JsonProperty private final Money amount;
     @JsonProperty private final AddressResponse to;
     @JsonProperty private final BankAccountResponse bankAccount;
-    @JsonProperty private final String status;
     @JsonProperty private final String message;
     @JsonProperty private final Money price;
     @JsonProperty private final String url;
@@ -52,7 +51,6 @@ public class CheckResponse extends AbstractLobResponse {
         this.amount = amount;
         this.to = to;
         this.bankAccount = bankAccount;
-        this.status = status;
         this.message = message;
         this.price = price;
         this.url = url;
@@ -83,10 +81,6 @@ public class CheckResponse extends AbstractLobResponse {
 
     public BankAccountResponse getBankAccount() {
         return bankAccount;
-    }
-
-    public String getStatus() {
-        return status;
     }
 
     public String getMessage() {
@@ -122,7 +116,6 @@ public class CheckResponse extends AbstractLobResponse {
             ", amount=" + amount +
             ", to=" + to +
             ", bankAccount=" + bankAccount +
-            ", status='" + status + '\'' +
             ", message='" + message + '\'' +
             ", price=" + price +
             ", url='" + url + '\'' +

--- a/src/main/java/com/lob/protocol/response/JobResponse.java
+++ b/src/main/java/com/lob/protocol/response/JobResponse.java
@@ -15,7 +15,6 @@ public class JobResponse extends AbstractLobResponse {
     @JsonProperty("price") private final String price;
     @JsonProperty("to") private final AddressResponse to;
     @JsonProperty("from") private final AddressResponse from;
-    @JsonProperty("status") private final String status;
     @JsonProperty("tracking") private final TrackingResponse tracking;
     @JsonProperty("service") private final ServiceResponse service;
     @JsonProperty("objects") private final List<LobObjectResponse> objects;
@@ -26,7 +25,6 @@ public class JobResponse extends AbstractLobResponse {
             @JsonProperty("price") final String price,
             @JsonProperty("to") final AddressResponse to,
             @JsonProperty("from") final AddressResponse from,
-            @JsonProperty("status") final String status,
             @JsonProperty("tracking") final TrackingResponse tracking,
             @JsonProperty("service") final ServiceResponse service,
             @JsonProperty("objects") final List<LobObjectResponse> objects,
@@ -39,7 +37,6 @@ public class JobResponse extends AbstractLobResponse {
         this.price = price;
         this.to = to;
         this.from = from;
-        this.status = status;
         this.tracking = tracking;
         this.service = service;
         this.objects = objects;
@@ -61,10 +58,6 @@ public class JobResponse extends AbstractLobResponse {
         return from;
     }
 
-    public String getStatus() {
-        return status;
-    }
-
     public TrackingResponse getTracking() {
         return tracking;
     }
@@ -84,7 +77,6 @@ public class JobResponse extends AbstractLobResponse {
             ", price='" + price + '\'' +
             ", to=" + to +
             ", from=" + from +
-            ", status='" + status + '\'' +
             ", tracking='" + tracking + '\'' +
             ", service=" + service +
             ", objects=" + objects +

--- a/src/main/java/com/lob/protocol/response/LetterResponse.java
+++ b/src/main/java/com/lob/protocol/response/LetterResponse.java
@@ -20,7 +20,6 @@ public class LetterResponse extends AbstractLobResponse {
     @JsonProperty private final int pages;
     @JsonProperty private final boolean template;
     @JsonProperty private final Money price;
-    @JsonProperty private final String status;
     @JsonProperty private final String url;
     @JsonProperty private final DateTime expectedDeliveryDate;
 
@@ -35,7 +34,6 @@ public class LetterResponse extends AbstractLobResponse {
             @JsonProperty("pages") final int pages,
             @JsonProperty("template") final boolean template,
             @JsonProperty("price") final Money price,
-            @JsonProperty("status") final String status,
             @JsonProperty("url") final String url,
             @JsonProperty("expected_delivery_date") final DateTime expectedDeliveryDate,
             @JsonProperty("date_created") final DateTime dateCreated,
@@ -52,7 +50,6 @@ public class LetterResponse extends AbstractLobResponse {
         this.pages = pages;
         this.template = template;
         this.price = price;
-        this.status = status;
         this.url = url;
         this.expectedDeliveryDate = expectedDeliveryDate;
     }
@@ -75,8 +72,6 @@ public class LetterResponse extends AbstractLobResponse {
 
     public Money getPrice() { return price; }
 
-    public String getStatus() { return status; }
-
     public String getUrl() { return url; }
 
     public DateTime getExpectedDeliveryDate() { return expectedDeliveryDate; }
@@ -93,7 +88,6 @@ public class LetterResponse extends AbstractLobResponse {
                 ", pages=" + pages +
                 ", template=" + template +
                 ", price='" + price + "'" +
-                ", status='" + status + "'" +
                 ", url='" + url + "'" +
                 ", expectedDeliveryDate='" + expectedDeliveryDate + "'" +
                 super.toString();

--- a/src/main/java/com/lob/protocol/response/PostcardResponse.java
+++ b/src/main/java/com/lob/protocol/response/PostcardResponse.java
@@ -11,7 +11,6 @@ import java.util.Map;
 public class PostcardResponse extends AbstractLobResponse {
     @JsonProperty private final PostcardId id;
     @JsonProperty private final String message;
-    @JsonProperty private final String status;
     @JsonProperty private final SettingResponse setting;
     @JsonProperty private final AddressResponse to;
     @JsonProperty private final AddressResponse from;
@@ -21,7 +20,6 @@ public class PostcardResponse extends AbstractLobResponse {
     public PostcardResponse(
             @JsonProperty("id") final PostcardId id,
             @JsonProperty("message") final String message,
-            @JsonProperty("status") final String status,
             @JsonProperty("setting") final SettingResponse setting,
             @JsonProperty("to") final AddressResponse to,
             @JsonProperty("from") final AddressResponse from,
@@ -33,7 +31,6 @@ public class PostcardResponse extends AbstractLobResponse {
         super(dateCreated, dateModified, metadata, object);
         this.id = id;
         this.message = message;
-        this.status = status;
         this.setting = setting;
         this.to = to;
         this.from = from;
@@ -46,10 +43,6 @@ public class PostcardResponse extends AbstractLobResponse {
 
     public String getMessage() {
         return message;
-    }
-
-    public String getStatus() {
-        return status;
     }
 
     public SettingResponse getSetting() {
@@ -73,7 +66,6 @@ public class PostcardResponse extends AbstractLobResponse {
         return "PostcardResponse{" +
             "id=" + id +
             ", message='" + message + '\'' +
-            ", status='" + status + '\'' +
             ", setting=" + setting +
             ", to=" + to +
             ", from=" + from +

--- a/src/test/java/com/lob/client/test/AreaMailTest.java
+++ b/src/test/java/com/lob/client/test/AreaMailTest.java
@@ -54,7 +54,6 @@ public class AreaMailTest extends BaseTest {
         final ZipCodeRouteResponseList route = client.getZipCodeRoutes(routeRequest).get();
 
         assertTrue(response.getId() instanceof AreaMailId);
-        assertFalse(response.getStatus().isEmpty());
         assertFalse(response.getUrl().isEmpty());
         assertThat(response.getObject(), is("area"));
         assertTrue(response.getExpectedDeliveryDate() instanceof DateTime);

--- a/src/test/java/com/lob/client/test/CheckTest.java
+++ b/src/test/java/com/lob/client/test/CheckTest.java
@@ -109,7 +109,6 @@ public class CheckTest extends BaseTest {
 
         assertFalse(response.getMessage().isEmpty());
         assertFalse(response.getMemo().isEmpty());
-        assertFalse(response.getStatus().isEmpty());
         assertFalse(response.getUrl().isEmpty());
         assertTrue(response.getCheckNumber() > 0);
         assertTrue(response.getExpectedDeliveryDate() instanceof DateTime);

--- a/src/test/java/com/lob/client/test/JobTest.java
+++ b/src/test/java/com/lob/client/test/JobTest.java
@@ -81,7 +81,6 @@ public class JobTest extends BaseTest {
         assertThat(metadataResponse.getId(), is(response.getId()));
 
         assertFalse(response.getPrice().isEmpty());
-        assertFalse(response.getStatus().isEmpty());
 
         final JobRequest otherRequest = builder.butWith().objectIds(objects).build();
         assertTrue(otherRequest.getFrom() instanceof Or);

--- a/src/test/java/com/lob/client/test/LetterTest.java
+++ b/src/test/java/com/lob/client/test/LetterTest.java
@@ -82,7 +82,6 @@ public class LetterTest extends BaseTest {
         assertThat(response.getFrom().getId(), is(address.getId()));
         assertThat(response.getDescription(), is("letter"));
         assertTrue(response.getExpectedDeliveryDate() instanceof DateTime);
-        assertFalse(response.getStatus().isEmpty());
         assertFalse(response.getUrl().isEmpty());
         assertTrue(response.isColor());
         assertFalse(response.isDoubleSided());
@@ -95,8 +94,6 @@ public class LetterTest extends BaseTest {
 
         final LetterResponse metadataResponse = client.getLetters(Filters.ofMetadata(metadata)).get().get(0);
         assertThat(metadataResponse.getId(), is(response.getId()));
-
-        assertFalse(response.getStatus().isEmpty());
 
         final AddressRequest addrRequest = AddressRequest.builder()
             .name("Lob0")

--- a/src/test/java/com/lob/client/test/PostcardTest.java
+++ b/src/test/java/com/lob/client/test/PostcardTest.java
@@ -79,7 +79,6 @@ public class PostcardTest extends BaseTest {
         assertThat(metadataResponse.getId(), is(response.getId()));
 
         assertTrue(response.getPrice() instanceof Money);
-        assertFalse(response.getStatus().isEmpty());
 
         final PostcardRequest request = builder.build();
         assertNull(request.getMessage());


### PR DESCRIPTION
What: remove `status` field from postcards, letters, jobs and area mail response.

Why: it was removed from the latest version of the API

@pon @mgartner @elnaz @robinjoseph08 @neelk07 