### PR TITLE
feat(letters): add extra_service, return_envelope, and perforated_page

### DIFF
--- a/src/main/java/com/lob/protocol/request/LetterRequest.java
+++ b/src/main/java/com/lob/protocol/request/LetterRequest.java
@@ -1,9 +1,7 @@
 package com.lob.protocol.request;
 
-import com.lob.LobParamsBuilder;
 import com.lob.Or;
 import com.lob.id.AddressId;
-
 import java.io.File;
 import java.util.Collection;
 import java.util.Map;
@@ -19,6 +17,9 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
     private final Boolean color;
     private final Boolean doubleSided;
     private final Boolean template;
+    private final String extraService;
+    private final Boolean returnEnvelope;
+    private final Integer perforatedPage;
 
     public LetterRequest(
             final String description,
@@ -28,6 +29,9 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
             final Boolean color,
             final Boolean doubleSided,
             final Boolean template,
+            final String extraService,
+            final Boolean returnEnvelope,
+            final Integer perforatedPage,
             final Map<String, String> metadata,
             final Map<String, String> data) {
 
@@ -38,6 +42,9 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
         this.color = checkNotNull(color, "color is required");
         this.doubleSided = doubleSided;
         this.template = template;
+        this.extraService = extraService;
+        this.returnEnvelope = returnEnvelope;
+        this.perforatedPage = perforatedPage;
     }
 
     @Override
@@ -49,6 +56,9 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
             .put("color", color)
             .put("double_sided", doubleSided)
             .put("template", template)
+            .put("extra_service", extraService)
+            .put("return_envelope", returnEnvelope)
+            .put("perforated_page", perforatedPage)
             .build();
     }
 
@@ -64,6 +74,12 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
 
     public Boolean isTemplate() { return template; }
 
+    public String getExtraService() { return extraService; }
+
+    public Boolean isReturnEnvelope() { return returnEnvelope; }
+
+    public Integer getPerforatedPage() { return perforatedPage; }
+
     @Override
     public String toString() {
         return "LetterRequest{" +
@@ -73,6 +89,9 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
             ", color=" + color +
             ", doubleSided=" + doubleSided +
             ", template=" + template +
+            ", extraService=" + extraService +
+            ", returnEnvelope=" + returnEnvelope +
+            ", perforatedPage=" + perforatedPage +
             super.toString();
     }
 
@@ -85,6 +104,9 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
         private Boolean color;
         private Boolean doubleSided;
         private Boolean template;
+        private String extraService;
+        private Boolean returnEnvelope;
+        private Integer perforatedPage;
 
         private Builder() {}
 
@@ -153,6 +175,21 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
             return this;
         }
 
+        public Builder extraService(final String extraService) {
+            this.extraService = extraService;
+            return this;
+        }
+
+        public Builder returnEnvelope(final Boolean returnEnvelope) {
+            this.returnEnvelope = returnEnvelope;
+            return this;
+        }
+
+        public Builder perforatedPage(final Integer perforatedPage) {
+            this.perforatedPage = perforatedPage;
+            return this;
+        }
+
         public Builder butWith() {
             return new Builder()
                 .description(description)
@@ -162,12 +199,15 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
                 .color(color)
                 .doubleSided(doubleSided)
                 .template(template)
+                .extraService(extraService)
+                .returnEnvelope(returnEnvelope)
+                .perforatedPage(perforatedPage)
                 .metadata(metadata)
                 .data(data);
         }
 
         public LetterRequest build() {
-            return new LetterRequest(description, to, from, file, color, doubleSided, template, metadata, data);
+            return new LetterRequest(description, to, from, file, color, doubleSided, template, extraService, returnEnvelope, perforatedPage, metadata, data);
         }
     }
 }

--- a/src/main/java/com/lob/protocol/response/LetterResponse.java
+++ b/src/main/java/com/lob/protocol/response/LetterResponse.java
@@ -18,6 +18,9 @@ public class LetterResponse extends AbstractLobResponse {
     @JsonProperty private final boolean doubleSided;
     @JsonProperty private final int pages;
     @JsonProperty private final boolean template;
+    @JsonProperty private final String extraService;
+    @JsonProperty private final boolean returnEnvelope;
+    @JsonProperty private final Integer perforatedPage;
     @JsonProperty private final Money price;
     @JsonProperty private final String url;
     @JsonProperty private final DateTime expectedDeliveryDate;
@@ -31,6 +34,9 @@ public class LetterResponse extends AbstractLobResponse {
             @JsonProperty("double_sided") final boolean doubleSided,
             @JsonProperty("pages") final int pages,
             @JsonProperty("template") final boolean template,
+            @JsonProperty("extra_service") final String extraService,
+            @JsonProperty("return_envelope") final boolean returnEnvelope,
+            @JsonProperty("perforated_page") final Integer perforatedPage,
             @JsonProperty("price") final Money price,
             @JsonProperty("url") final String url,
             @JsonProperty("expected_delivery_date") final DateTime expectedDeliveryDate,
@@ -47,6 +53,9 @@ public class LetterResponse extends AbstractLobResponse {
         this.doubleSided = doubleSided;
         this.pages = pages;
         this.template = template;
+        this.extraService = extraService;
+        this.returnEnvelope = returnEnvelope;
+        this.perforatedPage = perforatedPage;
         this.price = price;
         this.url = url;
         this.expectedDeliveryDate = expectedDeliveryDate;
@@ -66,6 +75,12 @@ public class LetterResponse extends AbstractLobResponse {
 
     public boolean isTemplate() { return template; }
 
+    public String getExtraService() { return extraService; }
+
+    public boolean isReturnEnvelope() { return returnEnvelope; }
+
+    public Integer getPerforatedPage() { return perforatedPage; }
+
     public Money getPrice() { return price; }
 
     public String getUrl() { return url; }
@@ -82,6 +97,9 @@ public class LetterResponse extends AbstractLobResponse {
                 ", doubleSided=" + doubleSided +
                 ", pages=" + pages +
                 ", template=" + template +
+                ", extraService=" + extraService +
+                ", returnEnvelope=" + returnEnvelope +
+                ", perforatedPage=" + perforatedPage +
                 ", price='" + price + "'" +
                 ", url='" + url + "'" +
                 ", expectedDeliveryDate='" + expectedDeliveryDate + "'" +

--- a/src/test/java/com/lob/client/test/LetterTest.java
+++ b/src/test/java/com/lob/client/test/LetterTest.java
@@ -3,8 +3,6 @@ package com.lob.client.test;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.lob.ClientUtil;
-import com.lob.client.AsyncLobClient;
-import com.lob.client.LobClient;
 import com.lob.id.LetterId;
 import com.lob.protocol.request.AddressRequest;
 import com.lob.protocol.request.Filters;
@@ -86,6 +84,9 @@ public class LetterTest extends BaseTest {
         assertTrue(response.isColor());
         assertFalse(response.isDoubleSided());
         assertTrue(response.isTemplate());
+        assertNull(response.getExtraService());
+        assertFalse(response.isReturnEnvelope());
+        assertNull(response.getPerforatedPage());
         assertThat(response.getPages(), is(1));
         assertTrue(response.getId() instanceof LetterId);
         assertTrue(response.getPrice() instanceof Money);
@@ -121,5 +122,58 @@ public class LetterTest extends BaseTest {
         assertFalse(otherRequest.isColor());
         assertFalse(otherRequest.isDoubleSided());
         assertTrue(otherRequest.isTemplate());
+    }
+
+    @Test
+    public void testCreateCertifiedLetter() throws Exception {
+        final AddressResponse address = client.getAddresses(1).get().get(0);
+        final String file = "<html style='padding-top: 3in; margin: .5in;'>HTML Letter</html>";
+        final String extraService = "certified";
+
+        final LetterRequest.Builder builder = LetterRequest.builder()
+                .to(address.getId())
+                .from(address.getId())
+                .file(file)
+                .color(true)
+                .template(true)
+                .doubleSided(false)
+                .extraService(extraService)
+                .description("letter");
+
+        final LetterRequest request = builder.build();
+
+        assertThat(request.getExtraService(), is(extraService));
+
+        final LetterResponse response = client.createLetter(request).get();
+
+        assertThat(response.getExtraService(), is(extraService));
+    }
+
+    @Test
+    public void testCreateReturnEnvelopeLetter() throws Exception {
+        final AddressResponse address = client.getAddresses(1).get().get(0);
+        final String file = "<html style='padding-top: 3in; margin: .5in;'>HTML Letter</html>";
+        final int perforatedPage = 1;
+
+        final LetterRequest.Builder builder = LetterRequest.builder()
+                .to(address.getId())
+                .from(address.getId())
+                .file(file)
+                .color(true)
+                .template(true)
+                .doubleSided(false)
+                .returnEnvelope(true)
+                .perforatedPage(perforatedPage)
+                .description("letter");
+
+        final LetterRequest request = builder.build();
+
+        assertTrue(request.isReturnEnvelope());
+        assertThat(request.getPerforatedPage(), is(perforatedPage));
+
+        final LetterResponse response = client.createLetter(request).get();
+
+        assertTrue(response.isReturnEnvelope());
+        assertThat(response.getPerforatedPage(), is(perforatedPage));
     }
 }


### PR DESCRIPTION
### What

Add the capability to create letters with `extra_service`, `return_envelope`, and `perforated_page`.

### Why

They were missing from the wrapper despite the fact the API had the functionality.

@elnaz 