### PR TITLE
feat(id): remove checkIdentifierFor

### DIFF
--- a/src/main/java/com/lob/Util.java
+++ b/src/main/java/com/lob/Util.java
@@ -1,8 +1,5 @@
 package com.lob;
 
-import com.lob.protocol.request.AddressRequest;
-import com.lob.protocol.response.AddressResponse;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,21 +31,6 @@ public final class Util {
             throw new IllegalArgumentException(message);
         }
         return ref;
-    }
-
-    final private static String hexRegex = "[a-fA-F0-9]+";
-
-    public static String checkValidHex(final String s) {
-        // handle the null and empty check right away
-        if (checkNotNull(s).isEmpty()) {
-            throw new IllegalArgumentException("string cannot be empty!");
-        }
-
-        if (!s.matches(hexRegex)) {
-            throw new IllegalArgumentException("string " + s + " is not valid hex!");
-        }
-
-        return s;
     }
 
     public static <T> List<T> defensiveCopy(final Collection<T> original) {

--- a/src/main/java/com/lob/id/LobId.java
+++ b/src/main/java/com/lob/id/LobId.java
@@ -1,50 +1,13 @@
 package com.lob.id;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.lob.Util.checkNotNull;
-import static com.lob.Util.checkValidHex;
-
 public abstract class LobId implements StringValued {
-    private final static String SEP = "_";
-    private final static int ID_LENGTH = 20;
-
     protected final String id;
 
     protected LobId(final Prefix prefix, final String id) {
-        checkIdentifierFor(prefix, id);
         this.id = id;
-    }
-
-    private void checkIdentifierFor(final Prefix prefix, final String s) {
-        // Make sure the string isn't malformed
-        final String[] sepString = checkNotNull(s).split(SEP);
-        if (sepString == null || sepString.length != 2) {
-            throw new IllegalArgumentException("string " + s + " is not a valid identifier!");
-        }
-
-        // Make sure the string is 20 chars
-        if (s.length() != ID_LENGTH) {
-            throw new IllegalArgumentException("string " + s + " is not " + ID_LENGTH + " characters long!");
-        }
-
-        // Make sure the prefix matches
-        final Prefix parsedPrefix = Prefix.fromString(sepString[0]);
-        if (parsedPrefix == null) {
-            throw new IllegalArgumentException(sepString[0] + " is not a valid prefix!");
-        }
-        if (parsedPrefix != prefix) {
-            throw new IllegalArgumentException("string " + s + " is not an identifier for " + prefix.name + "!");
-        }
-
-        // Make sure the random string is hex
-        checkValidHex(sepString[1]);
-
-
-        // If we make it here, everything is good!
     }
 
     @Override
@@ -68,11 +31,7 @@ public abstract class LobId implements StringValued {
 
         final LobId lobId = (LobId) o;
 
-        if (!id.equals(lobId.id)) {
-            return false;
-        }
-
-        return true;
+        return id.equals(lobId.id);
     }
 
     @Override

--- a/src/test/java/com/lob/client/test/IdTest.java
+++ b/src/test/java/com/lob/client/test/IdTest.java
@@ -47,26 +47,6 @@ public class IdTest extends BaseTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testLobIdBad() throws Exception {
-        new FakeId("BLARGHBLARGHBLARGHBLA");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testLobIdBadLength() throws Exception {
-        new FakeId("adr_BLARGH");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testLobIdWrongPrefix() throws Exception {
-        new FakeId("obj_BLARGHBLARGHBLAR");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testLobIdBadPrefix() throws Exception {
-        new FakeId("blargh_BLARGHBLARGHB");
-    }
-
     @Test
     public void testLobId() throws Exception {
         final LobId id = AddressId.parse("adr_1111111111111111");

--- a/src/test/java/com/lob/client/test/UtilTest.java
+++ b/src/test/java/com/lob/client/test/UtilTest.java
@@ -28,16 +28,6 @@ public class UtilTest extends BaseTest {
         Util.checkPresent(OrCollection.typeA(Collections.emptyList()), "");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testValidHexWithEmptyString() throws Exception {
-        Util.checkValidHex("");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidHex() throws Exception {
-        Util.checkValidHex("NOT HEX AT ALL LOL");
-    }
-
     @Test
     public void testDefensiveCopyWithEmptyList() {
         assertEquals(Util.defensiveCopy(Collections.emptyList()), Collections.emptyList());


### PR DESCRIPTION
### What

Remove `checkIdentifierFor`.

### Why

Because it isn't necessary, and it was causing some tests to fail because they were pulling "new" `bank_address`es that had an id of `adr_bank_address` which isn't "valid".

@elnaz 