### PR TITLE
remove links to prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Here's a general overview of the Lob services available, click through to read m
 - [Postcards API](https://lob.com/services/postcards)
 - [Letters API](https://lob.com/services/letters)
 - [Checks API](https://lob.com/services/checks)
-- [Prints API](https://lob.com/services/sps)
-- [Area Mail API](https://lob.com/services/sam)
+- [Area Mail API](https://lob.com/services/area)
 - [Address Verification API](https://lob.com/verification/address)
 
 ### Registration
@@ -152,20 +151,6 @@ There are simple scripts to demonstrate how to create all the core Lob objects (
     - [Delete a Bank Account](https://lob.com/docs/java#bankaccounts_delete)
     - [Verify a Bank Account](https://lob.com/docs/java#bankaccounts_verify)
     - [List all Bank Accounts](https://lob.com/docs/java#bankaccounts_list)
-- **Prints API**
-  - [Jobs](https://lob.com/docs/java#jobs)
-    - [Create a Job](https://lob.com/docs/java#jobs_create)
-    - [Create a MultiObject Job](https://lob.com/docs/java#jobs_multi)
-    - [Retrieve a Job](https://lob.com/docs/java#jobs_retrieve)
-    - [List all Jobs](https://lob.com/docs/java#jobs_list)
-  - [Objects](https://lob.com/docs/java#objects)
-    - [Create an Object](https://lob.com/docs/java#objects_create)
-    - [Retrieve an Object](https://lob.com/docs/java#objects_retrieve)
-    - [Delete an Object](https://lob.com/docs/java#objects_delete)
-    - [List all Objects](https://lob.com/docs/java#objects_list)
-  - [Settings](https://lob.com/docs/java#settings)
-    - [Retrieve a Setting](https://lob.com/docs/java#settings_retrieve)
-    - [List all Settings](https://lob.com/docs/java#settings_list)
 - **Area Mail API**
   - [Areas](https://lob.com/docs/java#areas)
     - [Create an Area Mailing](https://lob.com/docs/java#areas_create)

--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ There are simple scripts to demonstrate how to create all the core Lob objects (
   - [API Changelog](https://lob.com/docs/java#changelog)
   - [HTML Examples](https://lob.com/docs/java#html-examples)
   - [Image Prepping](https://lob.com/docs/java#prepping)
-  - [Prints API Templates](https://lob.com/docs/java#prints-templates)
 
 ## Contributing
 


### PR DESCRIPTION
just removing broken links for now. we can update the actual wrappers' contents whenever we release the version deprecating jobs.