### PR TITLE
feat(version): update for 2015-11-23

### DIFF
--- a/src/main/java/com/lob/protocol/request/CheckRequest.java
+++ b/src/main/java/com/lob/protocol/request/CheckRequest.java
@@ -14,7 +14,7 @@ import static com.lob.Util.checkNotNull;
 
 public class CheckRequest extends AbstractDataFieldRequest implements HasLobParams {
     public static final String LOGO = "logo";
-    public static final String FILE = "file";
+    public static final String CHECK_BOTTOM = "check_bottom";
 
     private final Integer checkNumber; // optional parameter, needs to be null if not set
     private final BankAccountId bankAccount;
@@ -24,7 +24,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
     private final String message;
     private final String memo;
     private final LobParam logo;
-    private final LobParam file;
+    private final LobParam checkBottom;
 
     public CheckRequest(
             final Integer checkNumber,
@@ -35,7 +35,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
             final String message,
             final String memo,
             final LobParam logo,
-            final LobParam file,
+            final LobParam checkBottom,
             final Map<String, String> metadata,
             final Map<String, String> data,
             final String description) {
@@ -48,7 +48,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
         this.message = message;
         this.memo = memo;
         this.logo = logo;
-        this.file = file;
+        this.checkBottom = checkBottom;
     }
 
     @Override
@@ -62,7 +62,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
             .put("message", message)
             .put("memo", memo)
             .put(logo)
-            .put(file)
+            .put(checkBottom)
             .build();
     }
 
@@ -98,8 +98,13 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
         return logo;
     }
 
+    @Deprecated
     public LobParam getFile() {
-        return file;
+        return getCheckBottom();
+    }
+
+    public LobParam getCheckBottom() {
+        return checkBottom;
     }
 
     @Override
@@ -113,7 +118,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
             ", message='" + message + '\'' +
             ", memo='" + memo + '\'' +
             ", logo='" + logo + '\'' +
-            ", file='" + file + '\'' +
+            ", checkBottom='" + checkBottom + '\'' +
             super.toString();
     }
 
@@ -130,7 +135,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
         private String message;
         private String memo;
         private LobParam logo;
-        private LobParam file;
+        private LobParam checkBottom;
 
         private Builder() {}
 
@@ -214,18 +219,33 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
             return this;
         }
 
+        @Deprecated
         public Builder file(final String file) {
-            this.file = LobParam.strings(FILE, file);
-            return this;
+            return this.checkBottom(file);
         }
 
+        @Deprecated
         public Builder file(final File file) {
-            this.file = LobParam.file(FILE, file);
+            return this.checkBottom(file);
+        }
+
+        @Deprecated
+        public Builder file(final LobParam file) {
+            return this.checkBottom(file);
+        }
+
+        public Builder checkBottom(final String checkBottom) {
+            this.checkBottom = LobParam.strings(CHECK_BOTTOM, checkBottom);
             return this;
         }
 
-        public Builder file(final LobParam file) {
-            this.file = file;
+        public Builder checkBottom(final File checkBottom) {
+            this.checkBottom = LobParam.file(CHECK_BOTTOM, checkBottom);
+            return this;
+        }
+
+        public Builder checkBottom(final LobParam checkBottom) {
+            this.checkBottom = checkBottom;
             return this;
         }
 
@@ -239,14 +259,14 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
                 .message(message)
                 .memo(memo)
                 .logo(logo)
-                .file(file)
+                .checkBottom(checkBottom)
                 .metadata(metadata)
                 .data(data)
                 .description(description);
         }
 
         public CheckRequest build() {
-            return new CheckRequest(checkNumber, bankAccount, to, from, amount, message, memo, logo, file, metadata, data, description);
+            return new CheckRequest(checkNumber, bankAccount, to, from, amount, message, memo, logo, checkBottom, metadata, data, description);
         }
     }
 }

--- a/src/main/java/com/lob/protocol/response/LetterResponse.java
+++ b/src/main/java/com/lob/protocol/response/LetterResponse.java
@@ -71,6 +71,7 @@ public class LetterResponse extends AbstractLobResponse {
 
     public boolean isDoubleSided() { return doubleSided; }
 
+    @Deprecated
     public int getPages() { return pages; }
 
     public boolean isTemplate() { return template; }
@@ -81,6 +82,7 @@ public class LetterResponse extends AbstractLobResponse {
 
     public Integer getPerforatedPage() { return perforatedPage; }
 
+    @Deprecated
     public Money getPrice() { return price; }
 
     public String getUrl() { return url; }

--- a/src/main/java/com/lob/protocol/response/PostcardResponse.java
+++ b/src/main/java/com/lob/protocol/response/PostcardResponse.java
@@ -58,6 +58,7 @@ public class PostcardResponse extends AbstractLobResponse {
         return from;
     }
 
+    @Deprecated
     public Money getPrice() {
         return price;
     }

--- a/src/test/java/com/lob/client/test/CheckTest.java
+++ b/src/test/java/com/lob/client/test/CheckTest.java
@@ -205,6 +205,7 @@ public class CheckTest extends BaseTest {
                 .build())
             .amount(1000)
             .memo("Test Check")
+            .checkBottom("<h1 style='padding-top:4in;'>Demo Check</h1>")
             .build();
 
         final CheckResponse response = client.createCheck(request).get();

--- a/src/test/java/com/lob/client/test/LetterTest.java
+++ b/src/test/java/com/lob/client/test/LetterTest.java
@@ -87,9 +87,9 @@ public class LetterTest extends BaseTest {
         assertNull(response.getExtraService());
         assertFalse(response.isReturnEnvelope());
         assertNull(response.getPerforatedPage());
-        assertThat(response.getPages(), is(1));
+        assertThat(response.getPages(), is(0));
         assertTrue(response.getId() instanceof LetterId);
-        assertTrue(response.getPrice() instanceof Money);
+        assertNull(response.getPrice());
         assertThat(response.getMetadata().get("key0"), is(value0));
         assertThat(response.getMetadata().get("key1"), is(value1));
 

--- a/src/test/java/com/lob/client/test/PostcardTest.java
+++ b/src/test/java/com/lob/client/test/PostcardTest.java
@@ -81,7 +81,7 @@ public class PostcardTest extends BaseTest {
         final PostcardResponse metadataResponse = client.getPostcards(Filters.ofMetadata(metadata)).get().get(0);
         assertThat(metadataResponse.getId(), is(response.getId()));
 
-        assertTrue(response.getPrice() instanceof Money);
+        assertNull(response.getPrice());
 
         final PostcardRequest request = builder.build();
         assertNull(request.getMessage());


### PR DESCRIPTION
### What

Update to accommodate the new API version

### Notes

For this update, I decided to go for the "Deprecating" approach instead of the complete removal approach. Now when people update their wrapper, they'll see the functions are deprecated, but they will in fact still work. This was easy to do for these changes because all it was was a param rename.