### PR TITLE
feat(response): add tracking_events and other properties

### DIFF
--- a/src/main/java/com/lob/protocol/response/AbstractPagedResponseList.java
+++ b/src/main/java/com/lob/protocol/response/AbstractPagedResponseList.java
@@ -3,7 +3,6 @@ package com.lob.protocol.response;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 

--- a/src/main/java/com/lob/protocol/response/AbstractResponseList.java
+++ b/src/main/java/com/lob/protocol/response/AbstractResponseList.java
@@ -3,7 +3,6 @@ package com.lob.protocol.response;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 

--- a/src/main/java/com/lob/protocol/response/AddressDeleteResponse.java
+++ b/src/main/java/com/lob/protocol/response/AddressDeleteResponse.java
@@ -2,7 +2,6 @@ package com.lob.protocol.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.lob.id.AddressId;
-import com.lob.id.LobObjectId;
 
 public class AddressDeleteResponse extends AbstractDeleteResponse<AddressId> {
     public AddressDeleteResponse(

--- a/src/main/java/com/lob/protocol/response/AddressResponseList.java
+++ b/src/main/java/com/lob/protocol/response/AddressResponseList.java
@@ -1,11 +1,7 @@
 package com.lob.protocol.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.lob.Util;
-import com.lob.protocol.request.AddressRequest;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public class AddressResponseList extends AbstractPagedResponseList<AddressResponse> {

--- a/src/main/java/com/lob/protocol/response/LetterResponse.java
+++ b/src/main/java/com/lob/protocol/response/LetterResponse.java
@@ -3,11 +3,10 @@ package com.lob.protocol.response;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.lob.id.LetterId;
-import com.lob.protocol.request.LetterRequest;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
 
-import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 public class LetterResponse extends AbstractLobResponse {
@@ -24,6 +23,8 @@ public class LetterResponse extends AbstractLobResponse {
     @JsonProperty private final Money price;
     @JsonProperty private final String url;
     @JsonProperty private final DateTime expectedDeliveryDate;
+    @JsonProperty private final List<ThumbnailResponse> thumbnails;
+    @JsonProperty private final TrackingResponse tracking;
 
     @JsonCreator
     public LetterResponse(
@@ -40,6 +41,8 @@ public class LetterResponse extends AbstractLobResponse {
             @JsonProperty("price") final Money price,
             @JsonProperty("url") final String url,
             @JsonProperty("expected_delivery_date") final DateTime expectedDeliveryDate,
+            @JsonProperty("thumbnails") final List<ThumbnailResponse> thumbnails,
+            @JsonProperty("tracking") final TrackingResponse tracking,
             @JsonProperty("description") final String description,
             @JsonProperty("date_created") final DateTime dateCreated,
             @JsonProperty("date_modified") final DateTime dateModified,
@@ -59,6 +62,8 @@ public class LetterResponse extends AbstractLobResponse {
         this.price = price;
         this.url = url;
         this.expectedDeliveryDate = expectedDeliveryDate;
+        this.thumbnails = thumbnails;
+        this.tracking = tracking;
     }
 
     public LetterId getId() { return id; }
@@ -89,6 +94,10 @@ public class LetterResponse extends AbstractLobResponse {
 
     public DateTime getExpectedDeliveryDate() { return expectedDeliveryDate; }
 
+    public List<ThumbnailResponse> getThumbnails() { return thumbnails; }
+
+    public TrackingResponse getTracking() { return tracking; }
+
     @Override
     public String toString() {
         return "LetterResponse{" +
@@ -105,6 +114,8 @@ public class LetterResponse extends AbstractLobResponse {
                 ", price='" + price + "'" +
                 ", url='" + url + "'" +
                 ", expectedDeliveryDate='" + expectedDeliveryDate + "'" +
+                ", thumbnails='" + thumbnails + "'" +
+                ", tracking='" + tracking + "'" +
                 super.toString();
 
     }

--- a/src/main/java/com/lob/protocol/response/PostcardResponse.java
+++ b/src/main/java/com/lob/protocol/response/PostcardResponse.java
@@ -3,9 +3,11 @@ package com.lob.protocol.response;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.lob.id.PostcardId;
+import com.lob.id.StringId;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
 
+import java.util.List;
 import java.util.Map;
 
 public class PostcardResponse extends AbstractLobResponse {
@@ -15,6 +17,10 @@ public class PostcardResponse extends AbstractLobResponse {
     @JsonProperty private final AddressResponse to;
     @JsonProperty private final AddressResponse from;
     @JsonProperty private final Money price;
+    @JsonProperty private final String url;
+    @JsonProperty private final DateTime expectedDeliveryDate;
+    @JsonProperty private final List<ThumbnailResponse> thumbnails;
+    @JsonProperty private final TrackingResponse tracking;
 
     @JsonCreator
     public PostcardResponse(
@@ -24,8 +30,12 @@ public class PostcardResponse extends AbstractLobResponse {
             @JsonProperty("to") final AddressResponse to,
             @JsonProperty("from") final AddressResponse from,
             @JsonProperty("price") final Money price,
-            @JsonProperty("date_created") final DateTime dateCreated,
+            @JsonProperty("url") final String url,
+            @JsonProperty("expected_delivery_date") final DateTime expectedDeliveryDate,
+            @JsonProperty("thumbnails") final List<ThumbnailResponse> thumbnails,
+            @JsonProperty("tracking") final TrackingResponse tracking,
             @JsonProperty("description") final String description,
+            @JsonProperty("date_created") final DateTime dateCreated,
             @JsonProperty("date_modified") final DateTime dateModified,
             @JsonProperty("metadata") final Map<String, String> metadata,
             @JsonProperty("object") final String object) {
@@ -36,6 +46,10 @@ public class PostcardResponse extends AbstractLobResponse {
         this.to = to;
         this.from = from;
         this.price = price;
+        this.url = url;
+        this.expectedDeliveryDate = expectedDeliveryDate;
+        this.thumbnails = thumbnails;
+        this.tracking = tracking;
     }
 
     public PostcardId getId() {
@@ -63,6 +77,22 @@ public class PostcardResponse extends AbstractLobResponse {
         return price;
     }
 
+    public String getUrl() {
+        return url;
+    }
+
+    public DateTime getExpectedDeliveryDate() {
+        return expectedDeliveryDate;
+    }
+
+    public List<ThumbnailResponse> getThumbnails() {
+        return thumbnails;
+    }
+
+    public TrackingResponse getTracking() {
+        return tracking;
+    }
+
     @Override
     public String toString() {
         return "PostcardResponse{" +
@@ -72,6 +102,10 @@ public class PostcardResponse extends AbstractLobResponse {
             ", to=" + to +
             ", from=" + from +
             ", price='" + price + '\'' +
+            ", url='" + url + '\'' +
+            ", expectedDeliveryDate='" + expectedDeliveryDate + '\'' +
+            ", thumbnails='" + thumbnails + '\'' +
+            ", tracking='" + tracking + '\'' +
             super.toString();
     }
 }

--- a/src/main/java/com/lob/protocol/response/TrackingEventResponse.java
+++ b/src/main/java/com/lob/protocol/response/TrackingEventResponse.java
@@ -1,0 +1,71 @@
+package com.lob.protocol.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.lob.id.TrackingId;
+import org.joda.time.DateTime;
+
+import java.util.Collection;
+
+import static com.lob.Util.defensiveCopy;
+
+public class TrackingEventResponse {
+    @JsonProperty("name") private final String name;
+    @JsonProperty("location") private final String location;
+    @JsonProperty("time") private final DateTime time;
+    @JsonProperty("date_created") private final DateTime dateCreated;
+    @JsonProperty("date_modified") private final DateTime dateModified;
+    @JsonProperty("object") private final String object;
+
+    @JsonCreator
+    public TrackingEventResponse(
+        @JsonProperty("name") final String name,
+        @JsonProperty("location") final String location,
+        @JsonProperty("time") final DateTime time,
+        @JsonProperty("date_created") final DateTime dateCreated,
+        @JsonProperty("date_modified") final DateTime dateModified,
+        @JsonProperty("object") final String object) {
+            this.name = name;
+            this.location = location;
+            this.time = time;
+            this.dateCreated = dateCreated;
+            this.dateModified = dateModified;
+            this.object = object;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public DateTime getTime() {
+        return time;
+    }
+
+    public DateTime getDateCreated() {
+        return dateCreated;
+    }
+
+    public DateTime getDateModified() {
+        return dateModified;
+    }
+
+    public String getObject() {
+        return object;
+    }
+
+    @Override
+    public String toString() {
+        return "TrackingEventResponse{" +
+            "name='" + name + '\'' +
+            ", location='" + location + '\'' +
+            ", time='" + time + '\'' +
+            ", dateCreated=" + dateCreated +
+            ", dateModified=" + dateModified +
+            ", object='" + object + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/com/lob/protocol/response/TrackingResponse.java
+++ b/src/main/java/com/lob/protocol/response/TrackingResponse.java
@@ -4,17 +4,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.lob.id.TrackingId;
 
-import java.util.Collection;
-
-import static com.lob.Util.defensiveCopy;
-
+import java.util.List;
 
 public class TrackingResponse {
     @JsonProperty("id") private final TrackingId id;
     @JsonProperty("tracking_number") private final String trackingNumber;
 	@JsonProperty("carrier") private final String carrier;
 	@JsonProperty("link") private final String link;
-	@JsonProperty("events") private final Collection<String> events; // TODO: figure out what type events are
+	@JsonProperty("events") private final List<TrackingEventResponse> events;
 	@JsonProperty("object") private final String object;
 
     @JsonCreator
@@ -23,7 +20,7 @@ public class TrackingResponse {
         @JsonProperty("tracking_number") final String trackingNumber,
         @JsonProperty("carrier") final String carrier,
         @JsonProperty("link") final String link,
-        @JsonProperty("events") final Collection<String> events,
+        @JsonProperty("events") final List<TrackingEventResponse> events,
         @JsonProperty("object") final String object) {
             this.id = id;
             this.trackingNumber = trackingNumber;
@@ -49,8 +46,8 @@ public class TrackingResponse {
         return link;
     }
 
-    public Collection<String> getEvents() {
-        return defensiveCopy(events);
+    public List<TrackingEventResponse> getEvents() {
+        return events;
     }
 
     public String getObject() {

--- a/src/test/java/com/lob/client/test/LetterTest.java
+++ b/src/test/java/com/lob/client/test/LetterTest.java
@@ -87,6 +87,8 @@ public class LetterTest extends BaseTest {
         assertNull(response.getExtraService());
         assertFalse(response.isReturnEnvelope());
         assertNull(response.getPerforatedPage());
+        assertEquals(response.getThumbnails().size(), 1);
+        assertNotNull(response.getTracking());
         assertThat(response.getPages(), is(0));
         assertTrue(response.getId() instanceof LetterId);
         assertNull(response.getPrice());


### PR DESCRIPTION
### What

Add a more comprehensive list of properties to expose for our products (such as `thumbnails`, `url`, and `tracking`), including adding a `TrackingEventResponse` object.

### Why

Because it's being returned from the API, it should be exposed so our customers can utilize them.

### Notes

* I'm removing a lot of unnecessary imports in a few files as well.
* I'm converting some old references to `Collection` to `List` to provide a sense a ordering (and since a `List` is a subclass of `Collection`, this shouldn't break anything).

If you see I'm missing any properties, let me know. I'll like to get all of them in.

@mgartner 