### PR TITLE
Support API version 2016-03-21

### DIFF
--- a/lob-java-examples/src/main/java/com/lob/examples/CheckExample.java
+++ b/lob-java-examples/src/main/java/com/lob/examples/CheckExample.java
@@ -19,6 +19,7 @@ public class CheckExample extends BaseExample {
         final BankAccountRequest exampleBankAccountRequest = BankAccountRequest.builder()
             .routingNumber("122100024")
             .accountNumber("1234564789")
+            .accountType("company")
             .signatory("John Doe")
             .build();
 

--- a/src/main/java/com/lob/protocol/request/BankAccountRequest.java
+++ b/src/main/java/com/lob/protocol/request/BankAccountRequest.java
@@ -9,17 +9,20 @@ import static com.lob.Util.checkPresent;
 public class BankAccountRequest extends AbstractLobRequest implements HasLobParams {
     private final String routingNumber;
     private final String accountNumber;
+    private final String accountType;
     private final String signatory;
 
     public BankAccountRequest(
             final String routingNumber,
             final String accountNumber,
+            final String accountType,
             final String signatory,
             final Map<String, String> metadata,
             final String description) {
         super(metadata, description);
         this.routingNumber = checkNotNull(routingNumber, "routing number is required");
         this.accountNumber = checkNotNull(accountNumber, "account number is required");
+        this.accountType = checkNotNull(accountType, "account type is required");
         this.signatory = checkPresent(signatory, "signatory is required");
     }
 
@@ -28,6 +31,7 @@ public class BankAccountRequest extends AbstractLobRequest implements HasLobPara
         return super.beginParams()
             .put("routing_number", routingNumber)
             .put("account_number", accountNumber)
+            .put("account_type", accountType)
             .put("signatory", signatory)
             .build();
     }
@@ -40,6 +44,10 @@ public class BankAccountRequest extends AbstractLobRequest implements HasLobPara
         return accountNumber;
     }
 
+    public String getAccountType() {
+        return accountType;
+    }
+
     public String getSignatory() {
         return signatory;
     }
@@ -49,6 +57,7 @@ public class BankAccountRequest extends AbstractLobRequest implements HasLobPara
         return "BankAccountRequest{" +
             "routingNumber='" + routingNumber + '\'' +
             ", accountNumber='" + accountNumber + '\'' +
+            ", accountType='" + accountType + '\'' +
             ", signatory='" + signatory + '\'' +
             super.toString();
     }
@@ -60,6 +69,7 @@ public class BankAccountRequest extends AbstractLobRequest implements HasLobPara
     public static class Builder extends AbstractLobRequest.Builder<Builder> {
         private String routingNumber;
         private String accountNumber;
+        private String accountType;
         private String signatory;
 
         private Builder() {
@@ -75,6 +85,11 @@ public class BankAccountRequest extends AbstractLobRequest implements HasLobPara
             return this;
         }
 
+        public Builder accountType(final String accountType) {
+            this.accountType = accountType;
+            return this;
+        }
+
         public Builder signatory(final String signatory) {
             this.signatory = signatory;
             return this;
@@ -84,13 +99,14 @@ public class BankAccountRequest extends AbstractLobRequest implements HasLobPara
             return new Builder()
                 .routingNumber(routingNumber)
                 .accountNumber(accountNumber)
+                .accountType(accountType)
                 .signatory(signatory)
                 .metadata(metadata)
                 .description(description);
         }
 
         public BankAccountRequest build() {
-            return new BankAccountRequest(routingNumber, accountNumber, signatory, metadata, description);
+            return new BankAccountRequest(routingNumber, accountNumber, accountType, signatory, metadata, description);
         }
     }
 }

--- a/src/main/java/com/lob/protocol/response/BankAccountResponse.java
+++ b/src/main/java/com/lob/protocol/response/BankAccountResponse.java
@@ -11,6 +11,7 @@ public class BankAccountResponse extends AbstractLobResponse {
     @JsonProperty private final BankAccountId id;
     @JsonProperty private final String routingNumber;
     @JsonProperty private final String accountNumber;
+    @JsonProperty private final String accountType;
     @JsonProperty private final boolean verified;
     @JsonProperty private final String signatory;
 
@@ -19,6 +20,7 @@ public class BankAccountResponse extends AbstractLobResponse {
             @JsonProperty("id") final BankAccountId id,
             @JsonProperty("routing_number") final String routingNumber,
             @JsonProperty("account_number") final String accountNumber,
+            @JsonProperty("account_type") final String accountType,
             @JsonProperty("verified") final boolean verified,
             @JsonProperty("signatory") final String signatory,
             @JsonProperty("description") final String description,
@@ -30,6 +32,7 @@ public class BankAccountResponse extends AbstractLobResponse {
         this.id = id;
         this.routingNumber = routingNumber;
         this.accountNumber = accountNumber;
+        this.accountType = accountType;
         this.verified = verified;
         this.signatory = signatory;
     }
@@ -46,6 +49,10 @@ public class BankAccountResponse extends AbstractLobResponse {
         return accountNumber;
     }
 
+    public String getAccountType() {
+        return accountType;
+    }
+
     public boolean isVerified() {
         return verified;
     }
@@ -60,6 +67,7 @@ public class BankAccountResponse extends AbstractLobResponse {
             "id=" + id +
             ", routingNumber='" + routingNumber + '\'' +
             ", accountNumber='" + accountNumber + '\'' +
+            ", accountType='" + accountType + '\'' +
             ", verified=" + verified +
             ", signatory='" + signatory + '\'' +
             super.toString();

--- a/src/main/java/com/lob/protocol/response/TrackingResponse.java
+++ b/src/main/java/com/lob/protocol/response/TrackingResponse.java
@@ -10,7 +10,6 @@ public class TrackingResponse {
     @JsonProperty("id") private final TrackingId id;
     @JsonProperty("tracking_number") private final String trackingNumber;
 	@JsonProperty("carrier") private final String carrier;
-	@JsonProperty("link") private final String link;
 	@JsonProperty("events") private final List<TrackingEventResponse> events;
 	@JsonProperty("object") private final String object;
 
@@ -19,13 +18,11 @@ public class TrackingResponse {
         @JsonProperty("id") final TrackingId id,
         @JsonProperty("tracking_number") final String trackingNumber,
         @JsonProperty("carrier") final String carrier,
-        @JsonProperty("link") final String link,
         @JsonProperty("events") final List<TrackingEventResponse> events,
         @JsonProperty("object") final String object) {
             this.id = id;
             this.trackingNumber = trackingNumber;
             this.carrier = carrier;
-            this.link = link;
             this.events = events;
             this.object = object;
     }
@@ -42,10 +39,6 @@ public class TrackingResponse {
         return carrier;
     }
 
-    public String getLink() {
-        return link;
-    }
-
     public List<TrackingEventResponse> getEvents() {
         return events;
     }
@@ -60,7 +53,6 @@ public class TrackingResponse {
             "id='" + id + '\'' +
             ", trackingNumber='" + trackingNumber + '\'' +
             ", carrier='" + carrier + '\'' +
-            ", link='" + link + '\'' +
             ", events=" + events +
             ", object='" + object + '\'' +
             '}';

--- a/src/test/java/com/lob/client/test/BankAccountTest.java
+++ b/src/test/java/com/lob/client/test/BankAccountTest.java
@@ -61,6 +61,7 @@ public class BankAccountTest extends BaseTest {
         final BankAccountRequest.Builder builder = BankAccountRequest.builder()
             .routingNumber("122100024")
             .accountNumber("123456789")
+            .accountType("company")
             .signatory("John Doe")
             .description("bank account")
             .metadata(metadata);
@@ -70,6 +71,7 @@ public class BankAccountTest extends BaseTest {
         assertThat(response.getDescription(), is("bank account"));
         assertFalse(response.isVerified());
         assertFalse(response.getAccountNumber().isEmpty());
+        assertFalse(response.getAccountType().isEmpty());
         assertFalse(response.getRoutingNumber().isEmpty());
         assertFalse(response.getSignatory().isEmpty());
         assertThat(response.getMetadata().get("key0"), is(value0));
@@ -95,6 +97,7 @@ public class BankAccountTest extends BaseTest {
 
         final BankAccountRequest request = builder.build();
         assertFalse(request.getAccountNumber().isEmpty());
+        assertFalse(request.getAccountType().isEmpty());
         assertFalse(request.getRoutingNumber().isEmpty());
         assertFalse(request.getSignatory().isEmpty());
         assertNotNull(request.toString());

--- a/src/test/java/com/lob/client/test/CheckTest.java
+++ b/src/test/java/com/lob/client/test/CheckTest.java
@@ -48,9 +48,8 @@ public class CheckTest extends BaseTest {
         assertNotNull(response.getTracking().toString());
         assertNotNull(response.getTracking().getEvents());
         assertNotNull(response.getTracking().getId());
-        assertNotNull(response.getTracking().getTrackingNumber());
+        assertNull(response.getTracking().getTrackingNumber());
         assertNotNull(response.getTracking().getCarrier());
-        assertNull(response.getTracking().getLink());
         assertThat(response.getTracking().getObject(), is("tracking"));
         assertThat(responseList.getObject(), is("list"));
         assertNotNull(responseList.toString());

--- a/src/test/java/com/lob/client/test/PostcardTest.java
+++ b/src/test/java/com/lob/client/test/PostcardTest.java
@@ -183,9 +183,8 @@ public class PostcardTest extends BaseTest {
         final TrackingResponse trackings = response.getTracking();
 
         assertEquals(trackings.getId().toString(), "trk_b4bb17e6d0e5c3d4");
-        assertEquals(trackings.getTrackingNumber(), "897714123456789");
+        assertNull(trackings.getTrackingNumber());
         assertEquals(trackings.getCarrier(), "USPS");
-        assertNull(trackings.getLink());
         assertEquals(trackings.getEvents().size(), 1);
 
         final TrackingEventResponse event = trackings.getEvents().get(0);


### PR DESCRIPTION
- Adds support for accountType to bank accounts
- Updates the check example to provide an account type when creating a bank account
- Removes support for tracking link
- Updates tracking tests to expect a null tracking by default