### PR TITLE
feat(mail_type): allow custom mail_type with postcards, letters and checks

### DIFF
--- a/src/main/java/com/lob/protocol/request/CheckRequest.java
+++ b/src/main/java/com/lob/protocol/request/CheckRequest.java
@@ -27,6 +27,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
     private final LobParam logo;
     private final LobParam checkBottom;
     private final LobParam attachment;
+    private final String mailType;
 
     public CheckRequest(
             final Integer checkNumber,
@@ -39,6 +40,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
             final LobParam logo,
             final LobParam checkBottom,
             final LobParam attachment,
+            final String mailType,
             final Map<String, String> metadata,
             final Map<String, String> data,
             final String description) {
@@ -53,6 +55,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
         this.logo = logo;
         this.checkBottom = checkBottom;
         this.attachment = attachment;
+        this.mailType = mailType;
     }
 
     @Override
@@ -68,6 +71,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
             .put(logo)
             .put(checkBottom)
             .put(attachment)
+            .put("mail_type", mailType)
             .build();
     }
 
@@ -116,6 +120,10 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
         return attachment;
     }
 
+    public String getMailType() {
+        return mailType;
+    }
+
     @Override
     public String toString() {
         return "CheckRequest{" +
@@ -129,6 +137,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
             ", logo='" + logo + '\'' +
             ", checkBottom='" + checkBottom + '\'' +
             ", attachment='" + attachment + '\'' +
+            ", mailType='" + mailType + '\'' +
             super.toString();
     }
 
@@ -147,6 +156,7 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
         private LobParam logo;
         private LobParam checkBottom;
         private LobParam attachment;
+        private String mailType;
 
         private Builder() {}
 
@@ -275,6 +285,11 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
             return this;
         }
 
+        public Builder mailType(final String mailType) {
+            this.mailType = mailType;
+            return this;
+        }
+
         public Builder butWith() {
             return new Builder()
                 .checkNumber(checkNumber)
@@ -287,13 +302,14 @@ public class CheckRequest extends AbstractDataFieldRequest implements HasLobPara
                 .logo(logo)
                 .checkBottom(checkBottom)
                 .attachment(attachment)
+                .mailType(mailType)
                 .metadata(metadata)
                 .data(data)
                 .description(description);
         }
 
         public CheckRequest build() {
-            return new CheckRequest(checkNumber, bankAccount, to, from, amount, message, memo, logo, checkBottom, attachment, metadata, data, description);
+            return new CheckRequest(checkNumber, bankAccount, to, from, amount, message, memo, logo, checkBottom, attachment, mailType, metadata, data, description);
         }
     }
 }

--- a/src/main/java/com/lob/protocol/request/LetterRequest.java
+++ b/src/main/java/com/lob/protocol/request/LetterRequest.java
@@ -20,6 +20,7 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
     private final String extraService;
     private final Boolean returnEnvelope;
     private final Integer perforatedPage;
+    private final String mailType;
 
     public LetterRequest(
             final String description,
@@ -32,6 +33,7 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
             final String extraService,
             final Boolean returnEnvelope,
             final Integer perforatedPage,
+            final String mailType,
             final Map<String, String> metadata,
             final Map<String, String> data) {
 
@@ -45,6 +47,7 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
         this.extraService = extraService;
         this.returnEnvelope = returnEnvelope;
         this.perforatedPage = perforatedPage;
+        this.mailType = mailType;
     }
 
     @Override
@@ -59,6 +62,7 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
             .put("extra_service", extraService)
             .put("return_envelope", returnEnvelope)
             .put("perforated_page", perforatedPage)
+            .put("mail_type", mailType)
             .build();
     }
 
@@ -80,6 +84,8 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
 
     public Integer getPerforatedPage() { return perforatedPage; }
 
+    public String getMailType() { return mailType; }
+
     @Override
     public String toString() {
         return "LetterRequest{" +
@@ -92,6 +98,7 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
             ", extraService=" + extraService +
             ", returnEnvelope=" + returnEnvelope +
             ", perforatedPage=" + perforatedPage +
+            ", mailType=" + mailType +
             super.toString();
     }
 
@@ -107,6 +114,7 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
         private String extraService;
         private Boolean returnEnvelope;
         private Integer perforatedPage;
+        private String mailType;
 
         private Builder() {}
 
@@ -190,6 +198,11 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
             return this;
         }
 
+        public Builder mailType(final String mailType) {
+            this.mailType = mailType;
+            return this;
+        }
+
         public Builder butWith() {
             return new Builder()
                 .description(description)
@@ -202,12 +215,13 @@ public class LetterRequest extends AbstractDataFieldRequest implements HasLobPar
                 .extraService(extraService)
                 .returnEnvelope(returnEnvelope)
                 .perforatedPage(perforatedPage)
+                .mailType(mailType)
                 .metadata(metadata)
                 .data(data);
         }
 
         public LetterRequest build() {
-            return new LetterRequest(description, to, from, file, color, doubleSided, addressPlacement, extraService, returnEnvelope, perforatedPage, metadata, data);
+            return new LetterRequest(description, to, from, file, color, doubleSided, addressPlacement, extraService, returnEnvelope, perforatedPage, mailType, metadata, data);
         }
     }
 }

--- a/src/main/java/com/lob/protocol/request/PostcardRequest.java
+++ b/src/main/java/com/lob/protocol/request/PostcardRequest.java
@@ -19,6 +19,7 @@ public class PostcardRequest extends AbstractDataFieldRequest implements HasLobP
     private final LobParam front;
     private final LobParam back;
     private final String size;
+    private final String mailType;
 
     public PostcardRequest(
             final Or<AddressId, AddressRequest> to,
@@ -27,6 +28,7 @@ public class PostcardRequest extends AbstractDataFieldRequest implements HasLobP
             final LobParam front,
             final LobParam back,
             final String size,
+            final String mailType,
             final Map<String, String> metadata,
             final Map<String, String> data,
             final String description) {
@@ -38,6 +40,7 @@ public class PostcardRequest extends AbstractDataFieldRequest implements HasLobP
         this.front = checkNotNull(front, "front is required");
         this.back = back;
         this.size = size;
+        this.mailType = mailType;
     }
 
     @Override
@@ -47,6 +50,7 @@ public class PostcardRequest extends AbstractDataFieldRequest implements HasLobP
             .put("from", from)
             .put("message", message)
             .put("size", size)
+            .put("mail_type", mailType)
             .put(front)
             .put(back)
             .build();
@@ -76,6 +80,10 @@ public class PostcardRequest extends AbstractDataFieldRequest implements HasLobP
       return size;
     }
 
+    public String getMailType() {
+        return mailType;
+    }
+
     @Override
     public String toString() {
         return "PostcardRequest{" +
@@ -84,7 +92,8 @@ public class PostcardRequest extends AbstractDataFieldRequest implements HasLobP
             ", message='" + message + '\'' +
             ", front='" + front + '\'' +
             ", back='" + back + '\'' +
-            ", size=" + size +
+            ", size='" + size + '\'' +
+            ", mailType='" + mailType + '\'' +
             super.toString();
     }
 
@@ -99,6 +108,7 @@ public class PostcardRequest extends AbstractDataFieldRequest implements HasLobP
         private LobParam front;
         private LobParam back;
         private String size;
+        private String mailType;
 
         private Builder() {}
 
@@ -172,6 +182,11 @@ public class PostcardRequest extends AbstractDataFieldRequest implements HasLobP
             return this;
         }
 
+        public Builder mailType(final String mailType) {
+            this.mailType = mailType;
+            return this;
+        }
+
         public Builder butWith() {
             return new Builder()
                 .to(to)
@@ -180,13 +195,14 @@ public class PostcardRequest extends AbstractDataFieldRequest implements HasLobP
                 .front(front)
                 .back(back)
                 .size(size)
+                .mailType(mailType)
                 .metadata(metadata)
                 .data(data)
                 .description(description);
         }
 
         public PostcardRequest build() {
-            return new PostcardRequest(to, from, message, front, back, size, metadata, data, description);
+            return new PostcardRequest(to, from, message, front, back, size, mailType, metadata, data, description);
         }
     }
 }

--- a/src/main/java/com/lob/protocol/response/CheckResponse.java
+++ b/src/main/java/com/lob/protocol/response/CheckResponse.java
@@ -25,6 +25,7 @@ public class CheckResponse extends AbstractLobResponse {
     @JsonProperty private final String trackingNumber;
     @JsonProperty private final List<TrackingEventResponse> trackingEvents;
     @JsonProperty private final DateTime expectedDeliveryDate;
+    @JsonProperty private final String mailType;
     @JsonProperty private final List<ThumbnailResponse> thumbnails;
 
     @JsonCreator
@@ -45,6 +46,7 @@ public class CheckResponse extends AbstractLobResponse {
             @JsonProperty("date_created") final DateTime dateCreated,
             @JsonProperty("date_modified") final DateTime dateModified,
             @JsonProperty("expected_delivery_date") final DateTime expectedDeliveryDate,
+            @JsonProperty("mail_type") final String mailType,
             @JsonProperty("thumbnails") final List<ThumbnailResponse> thumbnails,
             @JsonProperty("metadata") final Map<String, String> metadata,
             @JsonProperty("object") final String object) {
@@ -62,6 +64,7 @@ public class CheckResponse extends AbstractLobResponse {
         this.trackingNumber = trackingNumber;
         this.trackingEvents = trackingEvents;
         this.expectedDeliveryDate = expectedDeliveryDate;
+        this.mailType = mailType;
         this.thumbnails = thumbnails;
     }
 
@@ -117,6 +120,10 @@ public class CheckResponse extends AbstractLobResponse {
         return expectedDeliveryDate;
     }
 
+    public String getMailType() {
+        return mailType;
+    }
+
     public List<ThumbnailResponse> getThumbnails() {
         return defensiveCopy(this.thumbnails);
     }
@@ -137,6 +144,7 @@ public class CheckResponse extends AbstractLobResponse {
             ", trackingNumber='" + trackingNumber + '\'' +
             ", trackingEvents='" + trackingEvents + '\'' +
             ", expectedDeliveryDate=" + expectedDeliveryDate +
+            ", mailType=" + mailType +
             ", thumbnails=" + thumbnails +
             super.toString();
     }

--- a/src/main/java/com/lob/protocol/response/LetterResponse.java
+++ b/src/main/java/com/lob/protocol/response/LetterResponse.java
@@ -25,6 +25,7 @@ public class LetterResponse extends AbstractLobResponse {
     @JsonProperty private final Money price;
     @JsonProperty private final String url;
     @JsonProperty private final DateTime expectedDeliveryDate;
+    @JsonProperty private final String mailType;
     @JsonProperty private final List<ThumbnailResponse> thumbnails;
     @JsonProperty private final String carrier;
     @JsonProperty private final String trackingNumber;
@@ -45,6 +46,7 @@ public class LetterResponse extends AbstractLobResponse {
             @JsonProperty("price") final Money price,
             @JsonProperty("url") final String url,
             @JsonProperty("expected_delivery_date") final DateTime expectedDeliveryDate,
+            @JsonProperty("mail_type") final String mailType,
             @JsonProperty("thumbnails") final List<ThumbnailResponse> thumbnails,
             @JsonProperty("carrier") final String carrier,
             @JsonProperty("tracking_number") final String trackingNumber,
@@ -68,6 +70,7 @@ public class LetterResponse extends AbstractLobResponse {
         this.price = price;
         this.url = url;
         this.expectedDeliveryDate = expectedDeliveryDate;
+        this.mailType = mailType;
         this.thumbnails = thumbnails;
         this.carrier = carrier;
         this.trackingNumber = trackingNumber;
@@ -102,6 +105,8 @@ public class LetterResponse extends AbstractLobResponse {
 
     public DateTime getExpectedDeliveryDate() { return expectedDeliveryDate; }
 
+    public String getMailType() { return mailType; }
+
     public List<ThumbnailResponse> getThumbnails() { return defensiveCopy(this.thumbnails); }
 
     public String getCarrier() { return carrier; }
@@ -126,6 +131,7 @@ public class LetterResponse extends AbstractLobResponse {
                 ", price='" + price + "'" +
                 ", url='" + url + "'" +
                 ", expectedDeliveryDate='" + expectedDeliveryDate + "'" +
+                ", mailType='" + mailType + "'" +
                 ", thumbnails='" + thumbnails + "'" +
                 ", carrier='" + carrier + "'" +
                 ", trackingNumber='" + trackingNumber + "'" +

--- a/src/main/java/com/lob/protocol/response/PostcardResponse.java
+++ b/src/main/java/com/lob/protocol/response/PostcardResponse.java
@@ -20,6 +20,7 @@ public class PostcardResponse extends AbstractLobResponse {
     @JsonProperty private final Money price;
     @JsonProperty private final String url;
     @JsonProperty private final DateTime expectedDeliveryDate;
+    @JsonProperty private final String mailType;
     @JsonProperty private final List<ThumbnailResponse> thumbnails;
     @JsonProperty private final String carrier;
     @JsonProperty private final List<TrackingEventResponse> trackingEvents;
@@ -34,6 +35,7 @@ public class PostcardResponse extends AbstractLobResponse {
             @JsonProperty("price") final Money price,
             @JsonProperty("url") final String url,
             @JsonProperty("expected_delivery_date") final DateTime expectedDeliveryDate,
+            @JsonProperty("mail_type") final String mailType,
             @JsonProperty("thumbnails") final List<ThumbnailResponse> thumbnails,
             @JsonProperty("carrier") final String carrier,
             @JsonProperty("tracking_events") final List<TrackingEventResponse> trackingEvents,
@@ -51,6 +53,7 @@ public class PostcardResponse extends AbstractLobResponse {
         this.price = price;
         this.url = url;
         this.expectedDeliveryDate = expectedDeliveryDate;
+        this.mailType = mailType;
         this.thumbnails = thumbnails;
         this.carrier = carrier;
         this.trackingEvents = trackingEvents;
@@ -89,6 +92,10 @@ public class PostcardResponse extends AbstractLobResponse {
         return expectedDeliveryDate;
     }
 
+    public String getMailType() {
+        return mailType;
+    }
+
     public List<ThumbnailResponse> getThumbnails() {
         return defensiveCopy(this.thumbnails);
     }
@@ -112,6 +119,7 @@ public class PostcardResponse extends AbstractLobResponse {
             ", price='" + price + '\'' +
             ", url='" + url + '\'' +
             ", expectedDeliveryDate='" + expectedDeliveryDate + '\'' +
+            ", mailType='" + mailType + '\'' +
             ", thumbnails='" + thumbnails + '\'' +
             ", carrier='" + carrier + '\'' +
             ", trackingEvents='" + trackingEvents + '\'' +

--- a/src/test/java/com/lob/client/test/LetterTest.java
+++ b/src/test/java/com/lob/client/test/LetterTest.java
@@ -188,6 +188,7 @@ public class LetterTest extends BaseTest {
         assertTrue(response.isReturnEnvelope());
         assertThat(response.getPerforatedPage(), is(perforatedPage));
     }
+
     @Test
     public void testDeleteLetter() throws Exception {
         final AddressResponse address = client.getAddresses(1).get().get(0);


### PR DESCRIPTION
### What
- [x] Adds the ability to pass in a custom `mail_type` with postcard, letter and check requests.
- [x] Creates and verifies a new bank account when creating checks to avoid race conditions with multiple tests running in parallel.
