### PR TITLE
fix(us-verification): make Component and Deliverability public

### DIFF
--- a/src/main/java/com/lob/protocol/response/USVerificationResponse.java
+++ b/src/main/java/com/lob/protocol/response/USVerificationResponse.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 
 public class USVerificationResponse extends AbstractResponse {
 
-    private static class Components {
+    public static class Components {
         private String primaryNumber;
         private String streetPredirection;
         private String streetName;
@@ -171,7 +171,7 @@ public class USVerificationResponse extends AbstractResponse {
         }
     }
 
-    private static class Deliverability {
+    public static class Deliverability {
         private String dpvConfirmation;
         private String dpvCmra;
         private String dpvVacant;

--- a/src/test/java/com/lob/client/test/USVerificationTest.java
+++ b/src/test/java/com/lob/client/test/USVerificationTest.java
@@ -23,6 +23,8 @@ public class USVerificationTest extends BaseTest {
         USVerificationResponse response = client.verifyUSAddress(request).get();
         assertThat(response.getPrimaryLine(), is("185 BERRY ST STE 6600"));
         assertThat(response.getDeliverability(), is("deliverable"));
+        assertThat(response.getComponents().getPrimaryNumber(), is("185"));
+        assertThat(response.getDeliverabilityAnalysis().getDpvConfirmation(), is("Y"));
     }
 
 }


### PR DESCRIPTION
**What**
- [x] Make `Components` and `Deliverability` classes public so you can access their properties from `USVerificationResponse` object.