### PR TITLE
chore(httpClient): add HTTP base with Address retrieve/list resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,70 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.lob</groupId>
+    <artifactId>lob-java</artifactId>
+    <packaging>jar</packaging>
+    <version>7.0.0-SNAPSHOT</version>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Parent pom for the Lob API Java Wrapper</description>
+    <url>https://github.com/lob/lob-java</url>
+
+    <licenses>
+        <license>
+            <name>The MIT License</name>
+            <url>http://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:https://github.com/lob/lob-java.git</connection>
+        <developerConnection>scm:git:https://github.com/lob/lob-java.git</developerConnection>
+        <url>https://github.com/lob/lob-java</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <commons-codec.version>1.10</commons-codec.version>
+        <jackson.version>2.5.1</jackson.version>
+        <joda.time.version>2.9.4</joda.time.version>
+        <junit.version>4.12</junit.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>${joda.time.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/lob/Lob.java
+++ b/src/main/java/com/lob/Lob.java
@@ -1,0 +1,20 @@
+package com.lob;
+
+public class Lob {
+
+    public static final String API_BASE_URL = "https://api.lob.com/v1/";
+    public static final String VERSION = "7.0.0";
+
+    public static String apiKey;
+    public static String apiVersion;
+
+    public static void init(final String apiKey) {
+        Lob.apiKey = apiKey;
+    }
+
+    public static void init(final String apiKey, final String apiVersion) {
+        Lob.apiKey = apiKey;
+        Lob.apiVersion = apiVersion;
+    }
+
+}

--- a/src/main/java/com/lob/exception/APIException.java
+++ b/src/main/java/com/lob/exception/APIException.java
@@ -1,0 +1,21 @@
+package com.lob.exception;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public class APIException extends LobException {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonCreator
+    public APIException(
+            @JsonProperty("error") final Map<String, Object> error) {
+        super((String)error.get("message"), (Integer)error.get("status_code"));
+    }
+
+    public APIException(String message, Integer statusCode,Throwable e) {
+        super(message, statusCode, e);
+    }
+
+}

--- a/src/main/java/com/lob/exception/AuthenticationException.java
+++ b/src/main/java/com/lob/exception/AuthenticationException.java
@@ -1,0 +1,11 @@
+package com.lob.exception;
+
+public class AuthenticationException extends LobException {
+
+    public AuthenticationException(String message, Integer statusCode) {
+        super(message, statusCode);
+    }
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/com/lob/exception/LobException.java
+++ b/src/main/java/com/lob/exception/LobException.java
@@ -1,0 +1,23 @@
+package com.lob.exception;
+
+public abstract class LobException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer statusCode;
+
+    public LobException(String message, Integer statusCode) {
+        super(message, null);
+        this.statusCode = statusCode;
+    }
+
+    public LobException(String message, Integer statusCode, Throwable e) {
+        super(message, e);
+        this.statusCode = statusCode;
+    }
+
+    public Integer getStatusCode() {
+        return statusCode;
+    }
+
+}

--- a/src/main/java/com/lob/model/Address.java
+++ b/src/main/java/com/lob/model/Address.java
@@ -1,0 +1,177 @@
+package com.lob.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.lob.exception.APIException;
+import com.lob.net.APIResource;
+import com.lob.net.LobResponse;
+import com.lob.net.RequestOptions;
+import java.util.Map;
+import org.joda.time.DateTime;
+
+public class Address extends APIResource {
+
+    public static final String ENDPOINT = "addresses";
+
+    @JsonProperty private final String id;
+    @JsonProperty private final String description;
+    @JsonProperty private final String name;
+    @JsonProperty private final String company;
+    @JsonProperty private final String phone;
+    @JsonProperty private final String email;
+    @JsonProperty private final String line1;
+    @JsonProperty private final String line2;
+    @JsonProperty private final String city;
+    @JsonProperty private final String state;
+    @JsonProperty private final String zip;
+    @JsonProperty private final String country;
+    @JsonProperty private final Map<String, String> metadata;
+    @JsonProperty private final DateTime dateCreated;
+    @JsonProperty private final DateTime dateModified;
+    @JsonProperty private final String object;
+
+    @JsonCreator
+    public Address(
+            @JsonProperty("id") final String id,
+            @JsonProperty("description") final String description,
+            @JsonProperty("name") final String name,
+            @JsonProperty("company") final String company,
+            @JsonProperty("phone") final String phone,
+            @JsonProperty("email") final String email,
+            @JsonProperty("address_line1") final String line1,
+            @JsonProperty("address_line2") final String line2,
+            @JsonProperty("address_city") final String city,
+            @JsonProperty("address_state") final String state,
+            @JsonProperty("address_zip") final String zip,
+            @JsonProperty("address_country") final String country,
+            @JsonProperty("metadata") final Map<String, String> metadata,
+            @JsonProperty("date_created") final DateTime dateCreated,
+            @JsonProperty("date_modified") final DateTime dateModified,
+            @JsonProperty("object") final String object) {
+        this.id = id;
+        this.description = description;
+        this.name = name;
+        this.company = company;
+        this.phone = phone;
+        this.email = email;
+        this.line1 = line1;
+        this.line2 = line2;
+        this.city = city;
+        this.state = state;
+        this.zip = zip;
+        this.country = country;
+        this.metadata = metadata;
+        this.dateCreated = dateCreated;
+        this.dateModified = dateModified;
+        this.object = object;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCompany() {
+        return company;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getLine1() {
+        return line1;
+    }
+
+    public String getLine2() {
+        return line2;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public String getZip() {
+        return zip;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public DateTime getDateCreated() {
+        return dateCreated;
+    }
+
+    public DateTime getDateModified() {
+        return dateModified;
+    }
+
+    public String getObject() {
+        return object;
+    }
+
+    @Override
+    public String toString() {
+        return "Address{" +
+                "id=" + id +
+                ", description='" + description + '\'' +
+                ", name='" + name + '\'' +
+                ", company='" + company + '\'' +
+                ", phone='" + phone + '\'' +
+                ", line1='" + line1 + '\'' +
+                ", line2='" + line2 + '\'' +
+                ", city='" + city + '\'' +
+                ", state='" + state + '\'' +
+                ", country='" + country + '\'' +
+                ", metadata=" + metadata +
+                ", dateCreated=" + dateCreated +
+                ", dateModified=" + dateModified +
+                ", object=" + object +
+                '}';
+    }
+
+    public static LobResponse retrieve(String id) throws APIException, Exception {
+        return request(RequestMethod.GET, String.format("%s/%s", ENDPOINT, id), null, Address.class, null);
+    }
+
+    public static LobResponse retrieve(String id, RequestOptions options) throws APIException, Exception {
+        return request(RequestMethod.GET, String.format("%s/%s", ENDPOINT, id), null, Address.class, options);
+    }
+
+    public static LobResponse list() throws APIException, Exception {
+        return request(RequestMethod.GET, ENDPOINT, null, AddressCollection.class, null);
+    }
+
+    public static LobResponse list(Map<String, Object> params) throws APIException, Exception {
+        return request(RequestMethod.GET, ENDPOINT, params, AddressCollection.class, null);
+    }
+
+    public static LobResponse list(RequestOptions options) throws APIException, Exception {
+        return request(RequestMethod.GET, ENDPOINT, null, AddressCollection.class, options);
+    }
+
+    public static LobResponse list(Map<String, Object> params, RequestOptions options) throws APIException, Exception {
+        return request(RequestMethod.GET, ENDPOINT, params, AddressCollection.class, options);
+    }
+
+}

--- a/src/main/java/com/lob/model/AddressCollection.java
+++ b/src/main/java/com/lob/model/AddressCollection.java
@@ -1,0 +1,17 @@
+package com.lob.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class AddressCollection extends LobCollection<Address> {
+
+    @JsonCreator
+    public AddressCollection(
+            @JsonProperty("data") final List<Address> data,
+            @JsonProperty("count") final int count,
+            @JsonProperty("object") final String object) {
+        super(data, count, object);
+    }
+
+}

--- a/src/main/java/com/lob/model/LobCollection.java
+++ b/src/main/java/com/lob/model/LobCollection.java
@@ -1,0 +1,41 @@
+package com.lob.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public abstract class LobCollection<T> {
+    @JsonProperty private final List<T> data;
+    @JsonProperty private final int count;
+    @JsonProperty private final String object;
+
+    @JsonCreator
+    public LobCollection(List<T> data, final int count, final String object) {
+        this.data = data;
+        this.count = count;
+        this.object = object;
+    }
+
+    public List<T> getData() {
+        return data;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public String getObject() {
+        return object;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "{" +
+            "data=" + data +
+            ", count=" + count +
+            ", object=" + object +
+            '}';
+
+    }
+
+}

--- a/src/main/java/com/lob/net/APIResource.java
+++ b/src/main/java/com/lob/net/APIResource.java
@@ -1,0 +1,26 @@
+package com.lob.net;
+
+import com.lob.exception.APIException;
+import java.util.Map;
+
+public abstract class APIResource  {
+
+    private static ResponseGetter responseGetter = new ResponseGetter();
+
+    public static final String CHARSET = "UTF-8";
+
+    public enum RequestMethod {
+        GET, POST, DELETE
+    }
+
+    public enum RequestType {
+        NORMAL, MULTIPART
+    }
+
+    public static <T> LobResponse request(APIResource.RequestMethod method,
+                                  String url, Map<String, Object> params, Class<T> clazz,
+                                  RequestOptions options) throws APIException, Exception {
+        return responseGetter.request(method, url, params, clazz, RequestType.NORMAL, options);
+    }
+
+}

--- a/src/main/java/com/lob/net/IResponseGetter.java
+++ b/src/main/java/com/lob/net/IResponseGetter.java
@@ -1,0 +1,16 @@
+package com.lob.net;
+
+import com.lob.exception.APIException;
+import com.lob.exception.AuthenticationException;
+import java.io.IOException;
+import java.util.Map;
+
+public interface IResponseGetter {
+    <T> LobResponse request(
+            APIResource.RequestMethod method,
+            String url,
+            Map<String, Object> params,
+            Class<T> clazz,
+            APIResource.RequestType type,
+            RequestOptions options) throws AuthenticationException, APIException, IOException;
+}

--- a/src/main/java/com/lob/net/LobResponse.java
+++ b/src/main/java/com/lob/net/LobResponse.java
@@ -1,0 +1,35 @@
+package com.lob.net;
+
+import java.util.List;
+import java.util.Map;
+
+public class LobResponse<T> {
+
+    int responseCode;
+    T responseBody;
+    Map<String, List<String>> responseHeaders;
+
+    public LobResponse(int responseCode, T responseBody) {
+        this.responseCode = responseCode;
+        this.responseBody = responseBody;
+        this.responseHeaders = null;
+    }
+
+    public LobResponse(int responseCode, T responseBody, Map<String, List<String>> responseHeaders) {
+        this.responseCode = responseCode;
+        this.responseBody = responseBody;
+        this.responseHeaders = responseHeaders;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+    public T getResponseBody() {
+        return responseBody;
+    }
+
+    public Map<String, List<String>> getResponseHeaders() {
+        return responseHeaders;
+    }
+}

--- a/src/main/java/com/lob/net/RequestOptions.java
+++ b/src/main/java/com/lob/net/RequestOptions.java
@@ -1,0 +1,100 @@
+package com.lob.net;
+
+import com.lob.Lob;
+
+public class RequestOptions {
+    public static RequestOptions getDefault() {
+        return new RequestOptions(Lob.apiKey, Lob.apiVersion, null);
+    }
+
+    private final String apiKey;
+    private final String lobVersion;
+    private final String idempotencyKey;
+
+    private RequestOptions(String apiKey, String lobVersion, String idempotencyKey) {
+        this.apiKey = apiKey;
+        this.lobVersion = lobVersion;
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getLobVersion() {
+        return lobVersion;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RequestOptions that = (RequestOptions) o;
+
+        if (apiKey != null ? !apiKey.equals(that.apiKey) : that.apiKey != null) {
+            return false;
+        }
+
+        if (idempotencyKey != null ? !idempotencyKey.equals(that.idempotencyKey) : that.idempotencyKey != null) {
+            return false;
+        }
+
+        if (lobVersion != null ? !lobVersion.equals(that.lobVersion) : that.lobVersion != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static RequestOptionsBuilder builder() {
+        return new RequestOptionsBuilder();
+    }
+
+    public static final class RequestOptionsBuilder {
+        private String apiKey;
+        private String lobVersion;
+        private String idempotencyKey;
+
+        public RequestOptionsBuilder() {
+            this.apiKey = Lob.apiKey;
+            this.lobVersion = Lob.apiVersion;
+        }
+
+        public String getApiKey() {
+            return this.apiKey;
+        }
+
+        public RequestOptionsBuilder setApiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public RequestOptionsBuilder setLobVersion(String lobVersion) {
+            this.lobVersion = lobVersion;
+            return this;
+        }
+
+        public String getLobVersion() {
+            return this.lobVersion;
+        }
+
+        public RequestOptionsBuilder setIdempotencyKey(String idempotencyKey) {
+            this.idempotencyKey = idempotencyKey;
+            return this;
+        }
+
+        public String getIdempotencyKey() {
+            return this.idempotencyKey;
+        }
+
+        public RequestOptions build() {
+            return new RequestOptions(this.apiKey, this.lobVersion, this.idempotencyKey);
+        }
+    }
+
+}

--- a/src/main/java/com/lob/net/ResponseGetter.java
+++ b/src/main/java/com/lob/net/ResponseGetter.java
@@ -1,0 +1,187 @@
+package com.lob.net;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.lob.exception.APIException;
+import com.lob.exception.AuthenticationException;
+import com.lob.Lob;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.*;
+import org.apache.commons.codec.binary.Base64;
+
+import static com.lob.net.APIResource.CHARSET;
+import static com.lob.net.APIResource.RequestMethod.*;
+
+public class ResponseGetter implements IResponseGetter {
+
+    private final static ObjectMapper MAPPER = new ObjectMapper().registerModule(new JodaModule());
+
+    private final static class Parameter {
+        public final String key;
+        public final String value;
+
+        public Parameter(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    public <T> LobResponse request(
+            APIResource.RequestMethod method,
+            String url,
+            Map<String, Object> params,
+            Class<T> clazz,
+            APIResource.RequestType type,
+            RequestOptions options) throws AuthenticationException, APIException, IOException {
+        return _request(method, url, params, clazz, type, options);
+    }
+
+    static Map<String, String> getHeaders(RequestOptions options) {
+        Map<String, String> headers = new HashMap<String, String>();
+
+        headers.put("Authorization", String.format("Basic %s", Base64.encodeBase64String((options.getApiKey() + ":").getBytes())));
+        headers.put("User-Agent", String.format("LobJava/%s JDK/%s", Lob.VERSION, System.getProperty("java.version")));
+
+        if (options.getLobVersion() != null) {
+            headers.put("Lob-Version", options.getLobVersion());
+        }
+
+        if (options.getIdempotencyKey() != null) {
+            headers.put("Idempotency-Key", options.getIdempotencyKey());
+        }
+
+        return headers;
+    }
+
+    private static java.net.HttpURLConnection createDefaultConnection(String url, RequestOptions options) throws IOException {
+        URL lobURL = new URL(url);
+
+        HttpURLConnection conn = (HttpURLConnection) lobURL.openConnection();
+        conn.setUseCaches(false);
+        for (Map.Entry<String, String> header : getHeaders(options).entrySet()) {
+            conn.setRequestProperty(header.getKey(), header.getValue());
+        }
+
+        return conn;
+    }
+
+    private static java.net.HttpURLConnection createGetConnection(String url, String query, RequestOptions options) throws IOException {
+        String getURL = query.isEmpty() ? url : String.format("%s?%s", url, query);
+        java.net.HttpURLConnection conn = createDefaultConnection(getURL, options);
+
+        conn.setRequestMethod("GET");
+
+        return conn;
+    }
+
+    static String createQuery(Map<String, Object> params) throws UnsupportedEncodingException {
+        StringBuilder queryStringBuffer = new StringBuilder();
+        List<Parameter> flatParams = flattenParams(params);
+        Iterator<Parameter> it = flatParams.iterator();
+
+        while (it.hasNext()) {
+            if (queryStringBuffer.length() > 0) {
+                queryStringBuffer.append("&");
+            }
+            Parameter param = it.next();
+            queryStringBuffer.append(urlEncodePair(param.key, param.value));
+        }
+
+        return queryStringBuffer.toString();
+    }
+
+    private static String urlEncodePair(String key, String value) throws UnsupportedEncodingException {
+        return String.format("%s=%s", URLEncoder.encode(key, CHARSET), URLEncoder.encode(value, CHARSET));
+    }
+
+    private static List<Parameter> flattenParams(Map<String, Object> params) {
+        return flattenParamsMap(params, null);
+    }
+
+    private static List<Parameter> flattenParamsMap(Map<String, Object> params, String keyPrefix) {
+        List<Parameter> flatParams = new LinkedList<Parameter>();
+        if (params == null) {
+            return flatParams;
+        }
+
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            String newPrefix = key;
+            if (keyPrefix != null) {
+                newPrefix = String.format("%s[%s]", keyPrefix, key);
+            }
+
+            flatParams.addAll(flattenParamsValue(value, newPrefix));
+        }
+
+        return flatParams;
+    }
+
+    private static List<Parameter> flattenParamsValue(Object value, String keyPrefix) {
+        List<Parameter> flatParams;
+
+        if (value instanceof Map<?, ?>) {
+            flatParams = flattenParamsMap((Map<String, Object>) value, keyPrefix);
+        } else {
+            flatParams = new LinkedList<Parameter>();
+            flatParams.add(new Parameter(keyPrefix, value.toString()));
+        }
+
+        return flatParams;
+    }
+
+    private static <T> LobResponse makeURLConnectionRequest(APIResource.RequestMethod method, Class<T> clazz, String url, String query, RequestOptions options) throws APIException, IOException {
+        java.net.HttpURLConnection conn = null;
+        try {
+            if (method == GET) {
+                conn = createGetConnection(url, query, options);
+            } else {
+                conn = createGetConnection(url, query, options);
+            }
+
+            int responseCode = conn.getResponseCode();
+
+            if (responseCode >= 200 && responseCode < 300) {
+                Map<String, List<String>> headers = conn.getHeaderFields();
+                T value = MAPPER.readValue(conn.getInputStream(), clazz);
+
+                return new LobResponse<T>(responseCode, value, headers);
+            } else {
+                throw MAPPER.readValue(conn.getErrorStream(), APIException.class);
+            }
+        } catch (IOException e) {
+            throw e;
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    private static <T> LobResponse _request(APIResource.RequestMethod method,
+                                  String url, Map<String, Object> params, Class<T> clazz,
+                                  APIResource.RequestType type, RequestOptions options) throws AuthenticationException, APIException, IOException {
+        if (options == null) {
+            options = RequestOptions.getDefault();
+        }
+
+        String apiKey = options.getApiKey();
+        if (apiKey == null || apiKey.trim().length() == 0) {
+            throw new AuthenticationException("Missing API Key. Make sure 'Lob.init(<API_KEY>)' is called with a key from your Dashboard.", null);
+        }
+
+        LobResponse response;
+
+        String lobURL = String.format("%s%s", Lob.API_BASE_URL, url);
+        String query = createQuery(params);
+
+        return makeURLConnectionRequest(method, clazz, lobURL, query, options);
+    }
+
+}

--- a/src/test/java/com/lob/BaseTest.java
+++ b/src/test/java/com/lob/BaseTest.java
@@ -1,0 +1,12 @@
+package com.lob;
+
+import org.junit.BeforeClass;
+
+public class BaseTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        Lob.init("test_4c3bcf7696dbec938dbb34da8b311350dca");
+    }
+
+}

--- a/src/test/java/com/lob/model/AddressTest.java
+++ b/src/test/java/com/lob/model/AddressTest.java
@@ -1,0 +1,47 @@
+package com.lob.model;
+
+import com.lob.BaseTest;
+import com.lob.net.LobResponse;
+
+import org.junit.Test;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.*;
+
+public class AddressTest extends BaseTest {
+
+    @Test
+    public void testListAddresses() throws Exception {
+        LobResponse<AddressCollection> response = Address.list();
+
+        assertEquals(200, response.getResponseCode());
+        assertEquals(10, response.getResponseBody().getCount());
+        assertThat(response.getResponseBody().getData().get(0), instanceOf(Address.class));
+    }
+
+    @Test
+    public void testListAddressesWithParams() throws Exception {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("limit", 1);
+
+        LobResponse<AddressCollection> response = Address.list(params);
+
+        assertEquals(200, response.getResponseCode());
+        assertEquals(1, response.getResponseBody().getCount());
+        assertThat(response.getResponseBody().getData().get(0), instanceOf(Address.class));
+    }
+
+
+    @Test
+    public void testRetrieveAddress() throws Exception {
+        Address testAddress = ((AddressCollection) Address.list().getResponseBody()).getData().get(0);
+
+        LobResponse<Address> response = Address.retrieve(testAddress.getId());
+        Address address = response.getResponseBody();
+
+        assertEquals(testAddress.getId(), address.getId());
+    }
+
+}

--- a/src/test/java/com/lob/net/LobResponseTest.java
+++ b/src/test/java/com/lob/net/LobResponseTest.java
@@ -1,0 +1,34 @@
+package com.lob.net;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class LobResponseTest {
+
+    @Test
+    public void testLobResponse() {
+        final LobResponse response = new LobResponse(200, "{}");
+
+        assertEquals(200, response.getResponseCode());
+        assertEquals("{}", response.getResponseBody());
+        assertNull(response.getResponseHeaders());
+    }
+
+    @Test
+    public void testLobResponseWithHeaders() {
+        HashMap<String, List<String>> headers = new HashMap<String, List<String>>();
+        headers.put("User-Agent", Arrays.asList("LobBindingsTest"));
+
+        final LobResponse response = new LobResponse(200, "{}", headers);
+
+        assertEquals(200, response.getResponseCode());
+        assertEquals("{}", response.getResponseBody());
+        assertEquals(Arrays.asList("LobBindingsTest"), response.getResponseHeaders().get("User-Agent"));
+    }
+
+}

--- a/src/test/java/com/lob/net/RequestOptionsTest.java
+++ b/src/test/java/com/lob/net/RequestOptionsTest.java
@@ -1,0 +1,47 @@
+package com.lob.net;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RequestOptionsTest {
+
+    @Test
+    public void testRequestOptionsBuilder() throws Exception {
+        final RequestOptions options = RequestOptions.builder()
+                .setApiKey("test_123456789")
+                .setIdempotencyKey("123456789")
+                .build();
+
+        assertEquals("test_123456789", options.getApiKey());
+        assertNull(options.getLobVersion());
+        assertEquals("123456789", options.getIdempotencyKey());
+    }
+
+    @Test
+    public void testRequestOptionsBuilderGetters() throws Exception {
+        final RequestOptions.RequestOptionsBuilder optionsBuilder = RequestOptions.builder()
+                .setApiKey("test_123456789")
+                .setLobVersion("2017-99-99")
+                .setIdempotencyKey("123456789");
+
+        assertEquals("test_123456789", optionsBuilder.getApiKey());
+        assertEquals("2017-99-99", optionsBuilder.getLobVersion());
+        assertEquals("123456789", optionsBuilder.getIdempotencyKey());
+    }
+
+    @Test
+    public void testEquals() throws Exception {
+        final RequestOptions options = RequestOptions.getDefault();
+        final RequestOptions otherOptions = RequestOptions.getDefault();
+        final RequestOptions differetApiKeyOptions = RequestOptions.builder().setApiKey("test_123456789").build();
+        final RequestOptions differentVersionOptions = RequestOptions.builder().setLobVersion("2017-99-99").build();
+        final RequestOptions differentIdempotencyOptions = RequestOptions.builder().setIdempotencyKey("123456789").build();
+
+        assertEquals(options, otherOptions);
+        assertNotEquals(options, differetApiKeyOptions);
+        assertNotEquals(options, differentVersionOptions);
+        assertNotEquals(options, differentIdempotencyOptions);
+    }
+
+}

--- a/src/test/java/com/lob/net/ResponseGetterTest.java
+++ b/src/test/java/com/lob/net/ResponseGetterTest.java
@@ -1,0 +1,45 @@
+package com.lob.net;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResponseGetterTest {
+
+    @Test
+    public void testRequestOptionsBuilder() throws Exception {
+        final RequestOptions options = RequestOptions.builder()
+                .setApiKey("test_123456789")
+                .setLobVersion("2017-99-99")
+                .setIdempotencyKey("123456789")
+                .build();
+
+        final Map<String, String> headers = ResponseGetter.getHeaders(options);
+
+        assertEquals("Basic dGVzdF8xMjM0NTY3ODk6", headers.get("Authorization"));
+        assertThat(headers.get("User-Agent"), containsString("LobJava/"));
+        assertEquals("123456789", headers.get("Idempotency-Key"));
+    }
+
+    @Test
+    public void testCreateQuery() throws Exception {
+        final Map<String, Object> nested = new HashMap<String, Object>();
+        nested.put("b", "1");
+        nested.put("c", "2");
+
+        final Map<String, Object> query = new HashMap<String, Object>();
+        query.put("a", nested);
+        query.put("d", 3);
+
+        final String queryString = ResponseGetter.createQuery(query);
+
+        assertThat(queryString, containsString("a%5Bb%5D=1"));
+        assertThat(queryString, containsString("a%5Bc%5D=2"));
+        assertThat(queryString, containsString("d=3"));
+    }
+
+}


### PR DESCRIPTION
This is the first PR (of many) that includes the new Java wrapper.

**What**
- [x] Add the ability to make GET URL requests with parameters
- [x] Add `RequestOptions` which lets you add a custom API Key, Lob Version or Idempotency Key to each request
- [x] Add the Address model with the ability to retrieve an individual or collection of addresses
