### PR TITLE
chore(tests): fix area tests to be more resilient

### DIFF
--- a/src/test/java/com/lob/model/AreaTest.java
+++ b/src/test/java/com/lob/model/AreaTest.java
@@ -68,8 +68,8 @@ public class AreaTest extends BaseTest {
         assertNotNull(area.getId());
         assertEquals("Test Area", area.getDescription());
         assertNotNull(area.getZipCodes());
-        assertEquals(945, area.getAddresses());
-        assertEquals("735.21", area.getPrice());
+        assertTrue(area.getAddresses() > 0);
+        assertNotNull(area.getPrice());
         assertNotNull(area.getUrl());
         assertEquals("residential", area.getTargetType());
         assertNotNull(area.getThumbnails());
@@ -104,8 +104,8 @@ public class AreaTest extends BaseTest {
         assertNotNull(area.getId());
         assertEquals("Test Area", area.getDescription());
         assertNotNull(area.getZipCodes());
-        assertEquals(3591, area.getAddresses());
-        assertEquals("1310.72", area.getPrice());
+        assertTrue(area.getAddresses() > 0);
+        assertNotNull(area.getPrice());
         assertNotNull(area.getUrl());
         assertEquals("residential", area.getTargetType());
         assertNotNull(area.getThumbnails());


### PR DESCRIPTION
**What**
- [x] Remove tests to check the exact number and price of an area mail.

**Why**
The monthly delivery statistics update means that these values might change on a monthly basis. While the route will always be valid (in the near long-term) the price and number of addresses is likely to change thus break the previous test.