### PR TITLE
feat(us-verifications): allow passing queries in verification creation

### DIFF
--- a/src/main/java/com/lob/model/USVerification.java
+++ b/src/main/java/com/lob/model/USVerification.java
@@ -11,6 +11,7 @@ import com.lob.net.LobResponse;
 import com.lob.net.RequestOptions;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -452,11 +453,19 @@ public class USVerification extends APIResource {
         }
 
         public LobResponse<USVerification> verify() throws APIException, IOException, AuthenticationException, InvalidRequestException, RateLimitException {
-            return verify(null);
+            return verify(Collections.emptyMap(), null);
+        }
+
+        public LobResponse<USVerification> verify(Map<String, Object> query) throws APIException, IOException, AuthenticationException, InvalidRequestException, RateLimitException  {
+            return verify(query, null);
         }
 
         public LobResponse<USVerification> verify(RequestOptions options) throws APIException, IOException, AuthenticationException, InvalidRequestException, RateLimitException  {
-            return request(RequestMethod.POST, RequestType.NORMAL, ENDPOINT, params, USVerification.class, options);
+            return verify(Collections.emptyMap(), options);
+        }
+
+        public LobResponse<USVerification> verify(Map<String, Object> query, RequestOptions options) throws APIException, IOException, AuthenticationException, InvalidRequestException, RateLimitException  {
+            return request(RequestMethod.POST, RequestType.NORMAL, ENDPOINT, params, query, USVerification.class, options);
         }
     }
 

--- a/src/main/java/com/lob/net/APIResource.java
+++ b/src/main/java/com/lob/net/APIResource.java
@@ -23,9 +23,15 @@ public abstract class APIResource  {
     }
 
     public static <T> LobResponse<T> request(APIResource.RequestMethod method, APIResource.RequestType type,
-                                  String url, Map<String, Object> params, Class<T> clazz,
-                                  RequestOptions options) throws AuthenticationException, APIException, RateLimitException, InvalidRequestException, IOException {
+                                             String url, Map<String, Object> params, Class<T> clazz,
+                                             RequestOptions options) throws AuthenticationException, APIException, RateLimitException, InvalidRequestException, IOException {
         return responseGetter.request(method, url, params, clazz, type, options);
+    }
+
+    public static <T> LobResponse<T> request(APIResource.RequestMethod method, APIResource.RequestType type,
+                                             String url, Map<String, Object> params, Map<String, Object> query, Class<T> clazz,
+                                             RequestOptions options) throws AuthenticationException, APIException, RateLimitException, InvalidRequestException, IOException {
+        return responseGetter.request(method, url, params, query, clazz, type, options);
     }
 
 }

--- a/src/main/java/com/lob/net/IResponseGetter.java
+++ b/src/main/java/com/lob/net/IResponseGetter.java
@@ -12,7 +12,16 @@ public interface IResponseGetter {
     <T> LobResponse<T> request(
             APIResource.RequestMethod method,
             String url,
-            Map<String, Object> params,
+            Map<String, Object> data,
+            Map<String, Object> query,
+            Class<T> clazz,
+            APIResource.RequestType type,
+            RequestOptions options) throws AuthenticationException, APIException, RateLimitException, InvalidRequestException, IOException;
+
+    <T> LobResponse<T> request(
+            APIResource.RequestMethod method,
+            String url,
+            Map<String, Object> data,
             Class<T> clazz,
             APIResource.RequestType type,
             RequestOptions options) throws AuthenticationException, APIException, RateLimitException, InvalidRequestException, IOException;

--- a/src/test/java/com/lob/model/USVerificationTest.java
+++ b/src/test/java/com/lob/model/USVerificationTest.java
@@ -4,6 +4,9 @@ import com.lob.BaseTest;
 import com.lob.net.LobResponse;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -13,7 +16,7 @@ public class USVerificationTest extends BaseTest {
     public void testUsVerification() throws Exception {
         LobResponse<USVerification> response = new USVerification.RequestBuilder()
                 .setRecipient("Donald")
-                .setPrimaryLine("185 Berry St")
+                .setPrimaryLine("deliverable")
                 .setSecondaryLine("Ste 6100")
                 .setUrbanization("")
                 .setCity("San Francisco")
@@ -24,11 +27,37 @@ public class USVerificationTest extends BaseTest {
         USVerification usVerification = response.getResponseBody();
 
         assertEquals(200, response.getResponseCode());
-        assertEquals("DONALD", usVerification.getRecipient());
-        assertEquals("185 BERRY ST STE 6100", usVerification.getPrimaryLine());
+        assertEquals("1 TELEGRAPH HILL BLVD", usVerification.getPrimaryLine());
         assertEquals("", usVerification.getSecondaryLine());
         assertEquals("", usVerification.getUrbanization());
-        assertEquals("SAN FRANCISCO CA 94107-1234", usVerification.getLastLine());
+        assertEquals("SAN FRANCISCO CA 94133-3106", usVerification.getLastLine());
+        assertEquals("deliverable", usVerification.getDeliverability());
+        assertNotNull(usVerification.getComponents());
+        assertNotNull(usVerification.getDeliverabilityAnalysis());
+    }
+
+    @Test
+    public void testUsVerificationWithCustomCase() throws Exception {
+        Map<String, Object> query = new HashMap<>();
+        query.put("case", "proper");
+
+        LobResponse<USVerification> response = new USVerification.RequestBuilder()
+                .setRecipient("Donald")
+                .setPrimaryLine("deliverable")
+                .setSecondaryLine("Ste 6100")
+                .setUrbanization("")
+                .setCity("San Francisco")
+                .setState("CA")
+                .setZipCode("94107")
+                .verify(query);
+
+        USVerification usVerification = response.getResponseBody();
+
+        assertEquals(200, response.getResponseCode());
+        assertEquals("1 Telegraph Hill Blvd", usVerification.getPrimaryLine());
+        assertEquals("", usVerification.getSecondaryLine());
+        assertEquals("", usVerification.getUrbanization());
+        assertEquals("San Francisco CA 94133-3106", usVerification.getLastLine());
         assertEquals("deliverable", usVerification.getDeliverability());
         assertNotNull(usVerification.getComponents());
         assertNotNull(usVerification.getDeliverabilityAnalysis());


### PR DESCRIPTION
**What**
- [x] Allow a custom query to be passed in with on the `.verify()` call for USVerifications