### PR TITLE
feat(us-verifications): Support single line address verifications

### DIFF
--- a/src/main/java/com/lob/model/USVerification.java
+++ b/src/main/java/com/lob/model/USVerification.java
@@ -417,6 +417,11 @@ public class USVerification extends APIResource {
         public RequestBuilder() {
         }
 
+        public RequestBuilder setAddress(String address) {
+            params.put("address", address);
+            return this;
+        }
+
         public RequestBuilder setRecipient(String recipient) {
             params.put("recipient", recipient);
             return this;

--- a/src/test/java/com/lob/model/USVerificationTest.java
+++ b/src/test/java/com/lob/model/USVerificationTest.java
@@ -37,6 +37,24 @@ public class USVerificationTest extends BaseTest {
     }
 
     @Test
+    public void testUsVerificationSingleLineAddress() throws Exception {
+        LobResponse<USVerification> response = new USVerification.RequestBuilder()
+                .setAddress("deliverable")
+                .verify();
+
+        USVerification usVerification = response.getResponseBody();
+
+        assertEquals(200, response.getResponseCode());
+        assertEquals("1 TELEGRAPH HILL BLVD", usVerification.getPrimaryLine());
+        assertEquals("", usVerification.getSecondaryLine());
+        assertEquals("", usVerification.getUrbanization());
+        assertEquals("SAN FRANCISCO CA 94133-3106", usVerification.getLastLine());
+        assertEquals("deliverable", usVerification.getDeliverability());
+        assertNotNull(usVerification.getComponents());
+        assertNotNull(usVerification.getDeliverabilityAnalysis());
+    }
+    
+    @Test
     public void testUsVerificationWithCustomCase() throws Exception {
         Map<String, Object> query = new HashMap<>();
         query.put("case", "proper");


### PR DESCRIPTION
## What
- [x] Support `address` field in RequestBuilder for US verifications