### PR TITLE
test(api-key): remove lob api key from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
-
 jdk:
-  - oraclejdk8
+- oraclejdk8
+env:
+  global:
+    secure: DndOtST4+J5ZGTeZA6bgDX5Sfckw30jX3suXlIn8VkayybJXUx9/pPnNZo8uPR7QKpH94MgLawBANzx1l4rQc/lDurBmDflcQqKsF/dDBlGdWEXRluAm14vzGeZyXl5yS/zPIhSydfNJJnEYcrqg2MCcx7lrjBj9MZ7S1ygC6HI=

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Lob.init("yourApiKey", "yourApiVersion");
 
 ## Testing
 
-You can run all tests with the command `mvn test` in the main directory.
+You can run all tests with the command `LOB_API_KEY=<your_test_api_key> mvn test` in the main directory.
 
 =======================
 

--- a/src/test/java/com/lob/BaseTest.java
+++ b/src/test/java/com/lob/BaseTest.java
@@ -6,7 +6,7 @@ public class BaseTest {
 
     @BeforeClass
     public static void beforeClass() {
-        Lob.init("test_7b1960d06d6dfe28d3862b98380b8b0dc93");
+        Lob.init(System.getenv("LOB_API_KEY"));
     }
 
 }

--- a/src/test/java/com/lob/LobTest.java
+++ b/src/test/java/com/lob/LobTest.java
@@ -9,7 +9,7 @@ public class LobTest {
 
     @Test
     public void testLobInit() {
-        final String API_KEY = "test_7b1960d06d6dfe28d3862b98380b8b0dc93";
+        final String API_KEY = System.getenv("LOB_API_KEY");
 
         Lob.init(API_KEY);
         assertEquals(API_KEY, Lob.apiKey);
@@ -18,8 +18,8 @@ public class LobTest {
 
     @Test
     public void testLobInitWithApiVersion() {
-        final String API_KEY = "test_7b1960d06d6dfe28d3862b98380b8b0dc93";
-        final String API_VERSION = "    2017-09-01";
+        final String API_KEY = System.getenv("LOB_API_KEY");
+        final String API_VERSION = "2017-09-01";
 
         Lob.init(API_KEY, API_VERSION);
         assertEquals(API_KEY, Lob.apiKey);

--- a/src/test/java/com/lob/model/AddressTest.java
+++ b/src/test/java/com/lob/model/AddressTest.java
@@ -128,23 +128,4 @@ public class AddressTest extends BaseTest {
         new Address.RequestBuilder().create();
     }
 
-    @Test(expected = RateLimitException.class)
-    public void testAddressRateLimit() throws Exception {
-        RequestOptions options = new RequestOptions.Builder().setApiKey("test_03b4c5206b1f4c04b8d9fb5b4dd72ffd2d4").build();
-
-        new Address.RequestBuilder()
-                .setCompany("Lob.com")
-                .setName("Donald")
-                .setLine1("185 Berry St")
-                .setLine2("Ste 6600")
-                .setCity("San Francisco")
-                .setState("CA")
-                .setZip("94107")
-                .setCountry("US")
-                .setPhone("123-456-7890")
-                .setEmail("test@lob.com")
-                .setDescription("Java Wrapper Automated Test")
-                .create(options);
-    }
-
 }

--- a/src/test/java/com/lob/model/CheckTest.java
+++ b/src/test/java/com/lob/model/CheckTest.java
@@ -21,7 +21,7 @@ public class CheckTest extends BaseTest {
 
     @BeforeClass
     public static void beforeClass() {
-        Lob.init("test_7b1960d06d6dfe28d3862b98380b8b0dc93");
+        Lob.init(System.getenv("LOB_API_KEY"));
 
         try {
             BankAccount newBankAccount = new BankAccount.RequestBuilder()


### PR DESCRIPTION
## What
Remove lob api key from tests.

## Why
Users should be providing their own API key when running the tests since it creates production resources.

## Details
Adding encrypted api key to travis config: https://docs.travis-ci.com/user/environment-variables/#encrypting-environment-variables