### PR TITLE
feat(merge_variables): adds them to API response

### DIFF
--- a/src/main/java/com/lob/model/Check.java
+++ b/src/main/java/com/lob/model/Check.java
@@ -41,6 +41,7 @@ public class Check extends APIResource {
     @JsonProperty private final List<TrackingEvent> trackingEvents;
     @JsonProperty private final List<Thumbnail> thumbnails;
     @JsonProperty private final String mailType;
+    @JsonProperty private final Map<String, String> mergeVariables;
     @JsonProperty private final LocalDate expectedDeliveryDate;
     @JsonProperty private final ZonedDateTime dateCreated;
     @JsonProperty private final ZonedDateTime dateModified;
@@ -70,6 +71,7 @@ public class Check extends APIResource {
             @JsonProperty("tracking_events") final List<TrackingEvent> trackingEvents,
             @JsonProperty("thumbnails") final List<Thumbnail> thumbnails,
             @JsonProperty("mail_type") final String mailType,
+            @JsonProperty("merge_variables") final Map<String, String> mergeVariables,
             @JsonProperty("expected_delivery_date") final LocalDate expectedDeliveryDate,
             @JsonProperty("date_created") final ZonedDateTime dateCreated,
             @JsonProperty("date_modified") final ZonedDateTime dateModified,
@@ -96,6 +98,7 @@ public class Check extends APIResource {
         this.trackingEvents = trackingEvents;
         this.thumbnails = thumbnails;
         this.mailType = mailType;
+        this.mergeVariables = mergeVariables;
         this.expectedDeliveryDate = expectedDeliveryDate;
         this.dateCreated = dateCreated;
         this.dateModified = dateModified;
@@ -181,6 +184,10 @@ public class Check extends APIResource {
         return mailType;
     }
 
+    public Map<String, String> getMergeVariables() {
+        return mergeVariables;
+    }
+
     public LocalDate getExpectedDeliveryDate() {
         return expectedDeliveryDate;
     }
@@ -231,6 +238,7 @@ public class Check extends APIResource {
                 ", trackingEvents=" + trackingEvents +
                 ", thumbnails=" + thumbnails +
                 ", mailType='" + mailType + '\'' +
+                ", mergeVariables=" + mergeVariables +
                 ", expectedDeliveryDate=" + expectedDeliveryDate +
                 ", dateCreated=" + dateCreated +
                 ", dateModified=" + dateModified +

--- a/src/main/java/com/lob/model/Letter.java
+++ b/src/main/java/com/lob/model/Letter.java
@@ -70,6 +70,7 @@ public class Letter extends APIResource {
     @JsonProperty private final List<TrackingEvent> trackingEvents;
     @JsonProperty private final List<Thumbnail> thumbnails;
     @JsonProperty private final CustomEnvelope customEnvelope;
+    @JsonProperty private final Map<String, String> mergeVariables;
     @JsonProperty private final LocalDate expectedDeliveryDate;
     @JsonProperty private final ZonedDateTime dateCreated;
     @JsonProperty private final ZonedDateTime dateModified;
@@ -99,6 +100,7 @@ public class Letter extends APIResource {
             @JsonProperty("tracking_events") final List<TrackingEvent> trackingEvents,
             @JsonProperty("thumbnails") final List<Thumbnail> thumbnails,
             @JsonProperty("custom_envelope") final CustomEnvelope customEnvelope,
+            @JsonProperty("merge_variables") final Map<String, String> mergeVariables,
             @JsonProperty("expected_delivery_date") final LocalDate expectedDeliveryDate,
             @JsonProperty("date_created") final ZonedDateTime dateCreated,
             @JsonProperty("date_modified") final ZonedDateTime dateModified,
@@ -125,6 +127,7 @@ public class Letter extends APIResource {
         this.trackingEvents = trackingEvents;
         this.thumbnails = thumbnails;
         this.customEnvelope = customEnvelope;
+        this.mergeVariables = mergeVariables;
         this.expectedDeliveryDate = expectedDeliveryDate;
         this.dateCreated = dateCreated;
         this.dateModified = dateModified;
@@ -210,6 +213,10 @@ public class Letter extends APIResource {
         return customEnvelope;
     }
 
+    public Map<String, String> getMergeVariables() {
+        return mergeVariables;
+    }
+
     public LocalDate getExpectedDeliveryDate() {
         return expectedDeliveryDate;
     }
@@ -260,6 +267,7 @@ public class Letter extends APIResource {
                 ", trackingEvents=" + trackingEvents +
                 ", thumbnails=" + thumbnails +
                 ", customEnvelope=" + customEnvelope +
+                ", mergeVariables=" + mergeVariables +
                 ", expectedDeliveryDate=" + expectedDeliveryDate +
                 ", dateCreated=" + dateCreated +
                 ", dateModified=" + dateModified +

--- a/src/main/java/com/lob/model/Postcard.java
+++ b/src/main/java/com/lob/model/Postcard.java
@@ -36,6 +36,7 @@ public class Postcard extends APIResource {
     @JsonProperty private final List<Thumbnail> thumbnails;
     @JsonProperty private final String size;
     @JsonProperty private final String mailType;
+    @JsonProperty private final Map<String, String> mergeVariables;
     @JsonProperty private final LocalDate expectedDeliveryDate;
     @JsonProperty private final ZonedDateTime dateCreated;
     @JsonProperty private final ZonedDateTime dateModified;
@@ -60,6 +61,7 @@ public class Postcard extends APIResource {
             @JsonProperty("thumbnails") final List<Thumbnail> thumbnails,
             @JsonProperty("size") final String size,
             @JsonProperty("mail_type") final String mailType,
+            @JsonProperty("merge_variables") final Map<String, String> mergeVariables,
             @JsonProperty("expected_delivery_date") final LocalDate expectedDeliveryDate,
             @JsonProperty("date_created") final ZonedDateTime dateCreated,
             @JsonProperty("date_modified") final ZonedDateTime dateModified,
@@ -81,6 +83,7 @@ public class Postcard extends APIResource {
         this.thumbnails = thumbnails;
         this.size = size;
         this.mailType = mailType;
+        this.mergeVariables = mergeVariables;
         this.expectedDeliveryDate = expectedDeliveryDate;
         this.dateCreated = dateCreated;
         this.dateModified = dateModified;
@@ -146,6 +149,10 @@ public class Postcard extends APIResource {
         return mailType;
     }
 
+    public Map<String, String> getMergeVariables() {
+        return mergeVariables;
+    }
+
     public LocalDate getExpectedDeliveryDate() {
         return expectedDeliveryDate;
     }
@@ -191,6 +198,7 @@ public class Postcard extends APIResource {
                 ", thumbnails='" + thumbnails + '\'' +
                 ", size='" + size + '\'' +
                 ", mailType='" + mailType + '\'' +
+                ", mergeVariables=" + mergeVariables +
                 ", expectedDeliveryDate=" + expectedDeliveryDate +
                 ", dateCreated=" + dateCreated +
                 ", dateModified=" + dateModified +

--- a/src/test/java/com/lob/model/CheckTest.java
+++ b/src/test/java/com/lob/model/CheckTest.java
@@ -139,6 +139,7 @@ public class CheckTest extends BaseTest {
         assertNotNull(check.getTrackingEvents());
         assertNotNull(check.getThumbnails());
         assertEquals("usps_first_class", check.getMailType());
+        assertEquals(mergeVariables, check.getMergeVariables());
         assertNotNull(check.getExpectedDeliveryDate());
         assertNotNull(check.getDateCreated());
         assertNotNull(check.getDateModified());

--- a/src/test/java/com/lob/model/LetterTest.java
+++ b/src/test/java/com/lob/model/LetterTest.java
@@ -111,6 +111,7 @@ public class LetterTest extends BaseTest {
         assertNotNull(letter.getDateCreated());
         assertNotNull(letter.getDateModified());
         assertNotNull(letter.getSendDate());
+        assertEquals(mergeVariables, letter.getMergeVariables());
         assertEquals(metadata, letter.getMetadata());
         assertFalse(letter.isDeleted());
         assertEquals("letter", letter.getObject());

--- a/src/test/java/com/lob/model/PostcardTest.java
+++ b/src/test/java/com/lob/model/PostcardTest.java
@@ -106,6 +106,7 @@ public class PostcardTest extends BaseTest {
         assertNotNull(postcard.getThumbnails());
         assertEquals("4x6", postcard.getSize());
         assertEquals("usps_first_class", postcard.getMailType());
+        assertEquals(mergeVariables, postcard.getMergeVariables());
         assertNotNull(postcard.getExpectedDeliveryDate());
         assertNotNull(postcard.getDateCreated());
         assertNotNull(postcard.getDateModified());
@@ -191,6 +192,7 @@ public class PostcardTest extends BaseTest {
         assertNotNull(postcard.getThumbnails());
         assertEquals("4x6", postcard.getSize());
         assertEquals("usps_first_class", postcard.getMailType());
+        assertNull(postcard.getMergeVariables());
         assertNotNull(postcard.getExpectedDeliveryDate());
         assertNotNull(postcard.getDateCreated());
         assertNotNull(postcard.getDateModified());


### PR DESCRIPTION
**What:** Adds merge_variables to `postcards`, `checks`, and `letters` Java wrappers.

**Why:** Business ask from customers to be able to see the merge_variables they set previously.

**Details:**

- Makes it so customers can see the merge_variables that they set in the API response when using the Java Lob wrapper.
- Adds/refactors existing tests.

**Notes:**

- *JIRA:* [ENG-10673](https://lobsters.atlassian.net/browse/ENG-10673)
- *Related PRs:*
  - lob/lob-api#5190 (**DO NOT MERGE** until this PR is merged)
- *Affected endpoints:*
  - All `postcards` endpoints
  - All `checks` endpoints
  - All `letters` endpoints
- *Testing instructions:* Use the Java wrapper locally.