### PR TITLE
chore(travis): add openjdk10, openjdk11, oraclejdk11 and remove oraclejdk8 (deprecated)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk10
+  - openjdk11
+  - oraclejdk11


### PR DESCRIPTION
### What & Why
Update the JDK version we test our java library against. Travis has removed OracleJDK8 from their available JDKs so I've updated the list to all available development kits.