### PR TITLE
fix(zip): add ability to set zip code for autocomplete

### DIFF
--- a/src/main/java/com/lob/model/USAutocompletion.java
+++ b/src/main/java/com/lob/model/USAutocompletion.java
@@ -117,6 +117,11 @@ public class USAutocompletion extends APIResource {
             return this;
         }
 
+        public RequestBuilder setZipCode (String zipCode) {
+            params.put("zip_code", zipCode);
+            return this;
+        }
+
         public RequestBuilder setGeoIpSort (Boolean geoIpSort) {
             params.put("geo_ip_sort", geoIpSort);
             return this;

--- a/src/test/java/com/lob/model/USAutocompletionTest.java
+++ b/src/test/java/com/lob/model/USAutocompletionTest.java
@@ -15,6 +15,7 @@ public class USAutocompletionTest extends BaseTest {
             .setAddressPrefix("185 BER")
             .setCity("SAN FRANCISCO")
             .setState("CA")
+            .setZipCode("94107")
             .autocomplete();
 
         USAutocompletion usAutocompletion = response.getResponseBody();


### PR DESCRIPTION
## What & Why

Adds ability to set the `zip_code` param for autocomplete requests.