### PR TITLE
fix(check): use double for check amount and add setAmount(String amount)

### DIFF
--- a/src/main/java/com/lob/model/Check.java
+++ b/src/main/java/com/lob/model/Check.java
@@ -29,7 +29,7 @@ public class Check extends APIResource {
     @JsonProperty private final BankAccount bankAccount;
     @JsonProperty private final int checkNumber;
     @JsonProperty private final String memo;
-    @JsonProperty private final float amount;
+    @JsonProperty private final double amount;
     @JsonProperty private final String message;
     @JsonProperty private final String url;
     @JsonProperty private final String checkBottomTemplateId;
@@ -59,7 +59,7 @@ public class Check extends APIResource {
             @JsonProperty("bank_account") final BankAccount bankAccount,
             @JsonProperty("check_number") final int checkNumber,
             @JsonProperty("memo") final String memo,
-            @JsonProperty("amount") final float amount,
+            @JsonProperty("amount") final double amount,
             @JsonProperty("message") final String message,
             @JsonProperty("url") final String url,
             @JsonProperty("check_bottom_template_id") final String checkBottomTemplateId,
@@ -136,7 +136,7 @@ public class Check extends APIResource {
         return memo;
     }
 
-    public float getAmount() {
+    public double getAmount() {
         return amount;
     }
 
@@ -295,8 +295,8 @@ public class Check extends APIResource {
             params.put("check_number", checkNumber);
             return this;
         }
-
-        public RequestBuilder setAmount(float amount) {
+        
+        public RequestBuilder setAmount(String amount) {
             params.put("amount", amount);
             return this;
         }

--- a/src/test/java/com/lob/model/CheckTest.java
+++ b/src/test/java/com/lob/model/CheckTest.java
@@ -87,7 +87,7 @@ public class CheckTest extends BaseTest {
                 .setCheckBottom("<h1>Hello {{name}}</h1>")
                 .setAttachment("<h1>This is a HTML attachment</h1")
                 .setMergeVariables(mergeVariables)
-                .setAmount(1.00f)
+                .setAmount("1.00")
                 .setMemo("memo")
                 .setLogo("https://s3-us-west-2.amazonaws.com/public.lob.com/assets/check_logo.png")
                 .setTo(
@@ -127,7 +127,7 @@ public class CheckTest extends BaseTest {
         assertEquals(12345, check.getCheckNumber());
         assertEquals("memo", check.getMemo());
         assertNotNull(check.getUrl());
-        assertEquals(1.00f, check.getAmount(), 0.0001);
+        assertEquals(1.00, check.getAmount(), 0);
         assertNull(check.getMessage());
         assertNotNull(check.getUrl());
         assertNull(check.getCheckBottomTemplateId());
@@ -155,7 +155,7 @@ public class CheckTest extends BaseTest {
         LobResponse<Check> response = new Check.RequestBuilder()
                 .setCheckBottom("tmpl_c4aa2dc83ebad7e")
                 .setAttachment("tmpl_c4aa2dc83ebad7e")
-                .setAmount(1.00f)
+                .setAmount("1.00")
                 .setTo(
                         new Address.RequestBuilder()
                                 .setCompany("Lob.com")
@@ -195,7 +195,7 @@ public class CheckTest extends BaseTest {
 
         LobResponse<Check> response = new Check.RequestBuilder()
                 .setMessage("Hello Check")
-                .setAmount(1.00f)
+                .setAmount("1.00")
                 .setMemo("memo")
                 .setLogo(logo)
                 .setAttachment(attachment)
@@ -237,7 +237,7 @@ public class CheckTest extends BaseTest {
 
         LobResponse<Check> response = new Check.RequestBuilder()
                 .setDescription("Test Future Check")
-                .setAmount(1.00f)
+                .setAmount("1.00")
                 .setTo(
                         new Address.RequestBuilder()
                                 .setCompany("Lob.com")
@@ -269,10 +269,43 @@ public class CheckTest extends BaseTest {
     }
 
     @Test
+    public void testCreateCheckWithStringAmount() throws Exception {
+        LobResponse<Check> response = new Check.RequestBuilder()
+                .setAmount("131072.01")
+                .setTo(
+                        new Address.RequestBuilder()
+                                .setCompany("Lob.com")
+                                .setLine1("185 Berry St Ste 6100")
+                                .setCity("San Francisco")
+                                .setState("CA")
+                                .setZip("94107")
+                                .setCountry("US")
+                )
+                .setFrom(
+                        new Address.RequestBuilder()
+                                .setName("Donald")
+                                .setLine1("185 Berry St Ste 6100")
+                                .setCity("San Francisco")
+                                .setState("CA")
+                                .setZip("94107")
+                                .setCountry("US")
+                )
+                .setBankAccount(VERIFIED_BANK_ACCOUNT)
+                .setMailType("usps_first_class")
+                .create();
+
+        Check check = response.getResponseBody();
+
+        assertEquals(200, response.getResponseCode());
+        assertNotNull(check.getId());
+        assertEquals(131072.01, check.getAmount(), 0);
+    }
+
+    @Test
     public void testDeleteCheck() throws Exception {
         Check newCheck = new Check.RequestBuilder()
                 .setMessage("Check to be deleted")
-                .setAmount(1.00f)
+                .setAmount("1.00")
                 .setTo(
                         new Address.RequestBuilder()
                                 .setCompany("Lob.com")


### PR DESCRIPTION
### What & Why
- [x] Change `amount` in `Check` object to a `double` instead of `float` to account for check amounts with larger precision needs (amount greater than $10,000)
- [x] Remove `setAmount(float amount)` in favor of `setAmount(String amount)`.
  - If you have a numeric representation of the amount you'd like to create the check for you can use built-in functions to get the string represenation. Make sure you don't lose any precision while converting the number into a string. For example you can use [`BigDecimal.toPlainString()`](https://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html#toPlainString()) or [`Double.toString()`](https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#toString()).

Fixes #158 