### PR TITLE
Fix base64encodestring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.lob</groupId>
     <artifactId>lob-java</artifactId>
     <packaging>jar</packaging>
-    <version>12.3.6-SNAPSHOT</version>
+    <version>12.3.6</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Parent pom for the Lob API Java Wrapper</description>
@@ -27,7 +27,7 @@
         <connection>scm:git:git@github.com:lob/lob-java.git</connection>
         <developerConnection>scm:git:git@github.com:lob/lob-java.git</developerConnection>
         <url>https://github.com/lob/lob-java</url>
-        <tag>HEAD</tag>
+        <tag>v12.3.6</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.lob</groupId>
     <artifactId>lob-java</artifactId>
     <packaging>jar</packaging>
-    <version>12.3.6</version>
+    <version>12.3.7-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Parent pom for the Lob API Java Wrapper</description>
@@ -27,7 +27,7 @@
         <connection>scm:git:git@github.com:lob/lob-java.git</connection>
         <developerConnection>scm:git:git@github.com:lob/lob-java.git</developerConnection>
         <url>https://github.com/lob/lob-java</url>
-        <tag>v12.3.6</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/src/main/java/com/lob/net/ResponseGetter.java
+++ b/src/main/java/com/lob/net/ResponseGetter.java
@@ -75,7 +75,7 @@ public class ResponseGetter implements IResponseGetter {
     static Map<String, String> getHeaders(RequestOptions options) {
         Map<String, String> headers = new HashMap<String, String>();
 
-        headers.put("Authorization", String.format("Basic %s", Base64.encodeBase64String((options.getApiKey() + ":").getBytes())));
+        headers.put("Authorization", String.format("Basic %s", new String(Base64.encodeBase64((options.getApiKey() + ":").getBytes()))));
         headers.put("User-Agent", String.format("LobJava/%s JDK/%s", Lob.VERSION, System.getProperty("java.version")));
 
         if (options.getLobVersion() != null) {


### PR DESCRIPTION
Fix #157 

Android defaults to version 1.3 of apache.common.codec - even when a newer version is included you dependency.  For lob-java we specify version 1.10. 

Authorization header currently uses the method Base64.encodeBase64String() which is only supported in version 1.4 and higher of apache.common.codec.

To resolve this, I've replace Base64.encodeBase64String() with new String(Base64.encodeBase64()). 

Both achieve the same result, but with this new String() approach it is compatible with version 1.3 and higher of apache.common.codec.
