### PR TITLE
PLAT-2193: update deprecated GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build and Test
         uses: qcastel/github-actions-maven-cmd@master

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,10 +19,10 @@ jobs:
           cat .env
       - name: Checkout the repository
         uses: actions/checkout@v4
-      - name: Set up JDK 14
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 14
+          java-version: 17
           distribution: oracle
       - name: Cache Maven packages
         uses: actions/cache@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,13 +18,13 @@ jobs:
           echo LOB_API_TEST_KEY=${{ secrets.LOB_API_TEST_KEY }} >> .env
           cat .env
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK 14
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 14
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 14
+          distribution: oracle
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## JIRA

* [PLAT-2193](https://lobsters.atlassian.net/browse/PLAT-2193)

## Description

* `actions/checkout@v2`, `actions/setup-java@v1` and `actions/cache@v2` run Node 12 or 16 and are deprecated, we need them to run Node 20:

See:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
and
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

---

![image](https://github.com/lob/lob-java/assets/117756379/54a57e71-8f48-434f-bbd9-016c80dfb7fc)


[PLAT-2193]: https://lobsters.atlassian.net/browse/PLAT-2193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ